### PR TITLE
feat(web): migrate theme.js to typed theme.ts module (#45)

### DIFF
--- a/web/src/utils/theme.test.ts
+++ b/web/src/utils/theme.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest'
+import { renderMarkup, escapeHtml, THEME_TAGS } from '@/utils/theme'
+
+describe('theme', () => {
+  describe('THEME_TAGS', () => {
+    it('contains all expected tags', () => {
+      const expected = [
+        'character_name',
+        'dialogue',
+        'item_name',
+        'spell_name',
+        'room_name',
+        'quest_name',
+        'event',
+        'failure',
+        'success',
+        'exits',
+        'bold',
+        'dim',
+      ]
+      expect(THEME_TAGS).toEqual(expected)
+    })
+  })
+
+  describe('escapeHtml', () => {
+    it('escapes ampersands', () => {
+      expect(escapeHtml('A & B')).toBe('A &amp; B')
+    })
+
+    it('escapes angle brackets', () => {
+      expect(escapeHtml('<script>')).toBe('&lt;script&gt;')
+    })
+
+    it('escapes double quotes', () => {
+      expect(escapeHtml('"hello"')).toBe('&quot;hello&quot;')
+    })
+
+    it('escapes single quotes', () => {
+      expect(escapeHtml("it's")).toBe('it&#039;s')
+    })
+
+    it('handles multiple special characters', () => {
+      expect(escapeHtml('<a href="x">&</a>')).toBe(
+        '&lt;a href=&quot;x&quot;&gt;&amp;&lt;/a&gt;',
+      )
+    })
+
+    it('returns unchanged string with no special chars', () => {
+      expect(escapeHtml('hello world')).toBe('hello world')
+    })
+  })
+
+  describe('renderMarkup', () => {
+    it('returns empty string for empty input', () => {
+      expect(renderMarkup('')).toBe('')
+    })
+
+    it('returns empty string for null-ish input', () => {
+      expect(renderMarkup(undefined as unknown as string)).toBe('')
+      expect(renderMarkup(null as unknown as string)).toBe('')
+    })
+
+    it('converts character_name tag to span', () => {
+      expect(renderMarkup('[character_name]Mira[/character_name]')).toBe(
+        '<span class="theme-character_name">Mira</span>',
+      )
+    })
+
+    it('converts dialogue tag', () => {
+      expect(renderMarkup('[dialogue]Hello there![/dialogue]')).toBe(
+        '<span class="theme-dialogue">Hello there!</span>',
+      )
+    })
+
+    it('converts item_name tag', () => {
+      expect(renderMarkup('[item_name]Sword[/item_name]')).toBe(
+        '<span class="theme-item_name">Sword</span>',
+      )
+    })
+
+    it('converts spell_name tag', () => {
+      expect(renderMarkup('[spell_name]Fireball[/spell_name]')).toBe(
+        '<span class="theme-spell_name">Fireball</span>',
+      )
+    })
+
+    it('converts room_name tag', () => {
+      expect(renderMarkup('[room_name]Village[/room_name]')).toBe(
+        '<span class="theme-room_name">Village</span>',
+      )
+    })
+
+    it('converts quest_name tag', () => {
+      expect(renderMarkup('[quest_name]Find Key[/quest_name]')).toBe(
+        '<span class="theme-quest_name">Find Key</span>',
+      )
+    })
+
+    it('converts event tag', () => {
+      expect(renderMarkup('[event]Something happened![/event]')).toBe(
+        '<span class="theme-event">Something happened!</span>',
+      )
+    })
+
+    it('converts failure tag', () => {
+      expect(renderMarkup('[failure]You failed.[/failure]')).toBe(
+        '<span class="theme-failure">You failed.</span>',
+      )
+    })
+
+    it('converts success tag', () => {
+      expect(renderMarkup('[success]You succeeded![/success]')).toBe(
+        '<span class="theme-success">You succeeded!</span>',
+      )
+    })
+
+    it('converts exits tag', () => {
+      expect(renderMarkup('[exits]North, South[/exits]')).toBe(
+        '<span class="theme-exits">North, South</span>',
+      )
+    })
+
+    it('converts bold tag', () => {
+      expect(renderMarkup('[bold]Important[/bold]')).toBe(
+        '<span class="theme-bold">Important</span>',
+      )
+    })
+
+    it('converts dim tag', () => {
+      expect(renderMarkup('[dim]Faded text[/dim]')).toBe(
+        '<span class="theme-dim">Faded text</span>',
+      )
+    })
+
+    it('handles multiple tags in one string', () => {
+      const input =
+        '[character_name]Mira[/character_name] says [dialogue]Hello[/dialogue]'
+      const expected =
+        '<span class="theme-character_name">Mira</span> says ' +
+        '<span class="theme-dialogue">Hello</span>'
+      expect(renderMarkup(input)).toBe(expected)
+    })
+
+    it('handles nested tags', () => {
+      const input = '[bold][character_name]Mira[/character_name][/bold]'
+      const expected =
+        '<span class="theme-bold">' +
+        '<span class="theme-character_name">Mira</span></span>'
+      expect(renderMarkup(input)).toBe(expected)
+    })
+
+    it('converts newlines to <br>', () => {
+      expect(renderMarkup('line1\nline2')).toBe('line1<br>line2')
+    })
+
+    it('escapes HTML before applying tags', () => {
+      const input = '[bold]<script>alert("xss")</script>[/bold]'
+      const expected =
+        '<span class="theme-bold">' +
+        '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;</span>'
+      expect(renderMarkup(input)).toBe(expected)
+    })
+
+    it('leaves unknown tags as escaped text', () => {
+      expect(renderMarkup('[unknown]text[/unknown]')).toBe(
+        '[unknown]text[/unknown]',
+      )
+    })
+
+    it('handles multiple occurrences of the same tag', () => {
+      const input = '[bold]first[/bold] and [bold]second[/bold]'
+      const expected =
+        '<span class="theme-bold">first</span> and ' +
+        '<span class="theme-bold">second</span>'
+      expect(renderMarkup(input)).toBe(expected)
+    })
+
+    it('handles plain text with no tags', () => {
+      expect(renderMarkup('Just plain text.')).toBe('Just plain text.')
+    })
+  })
+})

--- a/web/src/utils/theme.ts
+++ b/web/src/utils/theme.ts
@@ -1,0 +1,65 @@
+/**
+ * Theme rendering: converts engine markup tags to styled HTML spans.
+ *
+ * The Python engine outputs strings with Rich-style markup like
+ * [character_name]Mira[/character_name]. This module converts those
+ * to <span class="theme-character_name">Mira</span> for CSS styling.
+ *
+ * Regexes are compiled once at module load time for performance.
+ */
+
+/** All known theme tags from engine/theme.py. */
+export const THEME_TAGS: readonly string[] = [
+  'character_name',
+  'dialogue',
+  'item_name',
+  'spell_name',
+  'room_name',
+  'quest_name',
+  'event',
+  'failure',
+  'success',
+  'exits',
+  'bold',
+  'dim',
+] as const
+
+/** Pre-compiled regex pairs for each tag: [openRegex, closeRegex, cssClass]. */
+const TAG_PATTERNS: Array<[RegExp, RegExp, string]> = THEME_TAGS.map((tag) => [
+  new RegExp(`\\[${tag}\\]`, 'g'),
+  new RegExp(`\\[/${tag}\\]`, 'g'),
+  `theme-${tag}`,
+])
+
+/**
+ * Escape HTML special characters to prevent XSS.
+ */
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;')
+}
+
+/**
+ * Convert engine markup tags to HTML spans with CSS classes.
+ *
+ * First escapes raw HTML, then replaces [tag]...[/tag] pairs with
+ * <span class="theme-tag">...</span>. Converts newlines to <br>.
+ */
+export function renderMarkup(text: string): string {
+  if (!text) return ''
+
+  let html = escapeHtml(text)
+
+  for (const [openRegex, closeRegex, cssClass] of TAG_PATTERNS) {
+    html = html.replace(openRegex, `<span class="${cssClass}">`)
+    html = html.replace(closeRegex, '</span>')
+  }
+
+  html = html.replace(/\n/g, '<br>')
+
+  return html
+}


### PR DESCRIPTION
## Summary
Migrate `theme.js` to a typed `theme.ts` module with pre-compiled regex patterns.

## Changes
- **`web/src/utils/theme.ts`**: Typed module exporting `THEME_TAGS`, `escapeHtml()`, and `renderMarkup()`. Regex patterns are compiled once at module scope instead of on every call.
- **`web/src/utils/theme.test.ts`**: 28 unit tests covering all 12 tag types, nested tags, XSS prevention, newline conversion, empty/null input, unknown tags, and multiple occurrences.

## Testing
- 61 tests pass (28 new + 33 existing)
- ESLint, Prettier, and vue-tsc all pass

Closes #45
