### PR TITLE
feat(#46): create Vue component structure

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -2,6 +2,7 @@ import js from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import pluginVue from 'eslint-plugin-vue'
 import prettierConfig from 'eslint-config-prettier'
+import globals from 'globals'
 
 export default tseslint.config(
   {
@@ -13,6 +14,7 @@ export default tseslint.config(
   {
     files: ['**/*.vue'],
     languageOptions: {
+      globals: globals.browser,
       parserOptions: {
         parser: tseslint.parser,
       },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,6 +15,7 @@
         "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-vue": "^10.8.0",
+        "globals": "^17.5.0",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.58.2",
@@ -1777,6 +1778,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ignore": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-vue": "^10.8.0",
+    "globals": "^17.5.0",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.2",

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,9 +1,7 @@
-<template>
-  <div id="retroquest-app">
-    <p>RetroQuest loading...</p>
-  </div>
-</template>
-
 <script setup lang="ts">
-// Minimal root component — will be expanded in later sub-issues.
+import GameLayout from './components/GameLayout.vue'
 </script>
+
+<template>
+  <GameLayout />
+</template>

--- a/web/src/components/ActionSheet.vue
+++ b/web/src/components/ActionSheet.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import type { MenuAction } from './ContextMenu.vue'
+
+defineProps<{
+  visible: boolean
+  target: string
+  actions: MenuAction[]
+}>()
+
+defineEmits<{
+  close: []
+  executeAction: [action: MenuAction]
+}>()
+</script>
+
+<template>
+  <div v-if="visible" class="action-sheet-overlay" @click.self="$emit('close')">
+    <div class="action-sheet">
+      <div class="action-sheet-handle"></div>
+      <div class="action-sheet-header">{{ target }}</div>
+      <div
+        v-for="action in actions"
+        :key="action.label"
+        class="action-sheet-item"
+        @click="$emit('executeAction', action)"
+      >
+        {{ action.label }}
+      </div>
+      <div class="action-sheet-cancel" @click="$emit('close')">Cancel</div>
+    </div>
+  </div>
+</template>

--- a/web/src/components/CommandInput.vue
+++ b/web/src/components/CommandInput.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+defineProps<{
+  acceptInput: boolean
+}>()
+
+const emit = defineEmits<{
+  submitCommand: [command: string]
+  advanceTurn: []
+}>()
+
+const commandInput = ref('')
+
+function onKeyEnter() {
+  emit('submitCommand', commandInput.value)
+  commandInput.value = ''
+}
+
+function onSendClick() {
+  emit('submitCommand', commandInput.value)
+  commandInput.value = ''
+}
+</script>
+
+<template>
+  <div>
+    <!-- Quick Action Bar -->
+    <div class="quick-actions">
+      <button class="quick-action-btn" @click="$emit('submitCommand', 'look')">
+        👀 Look
+      </button>
+      <button
+        class="quick-action-btn"
+        @click="$emit('submitCommand', 'search')"
+      >
+        🔍 Search
+      </button>
+      <button
+        class="quick-action-btn"
+        @click="$emit('submitCommand', 'inventory')"
+      >
+        🎒 Inventory
+      </button>
+      <button
+        class="quick-action-btn"
+        @click="$emit('submitCommand', 'spells')"
+      >
+        ✨ Spells
+      </button>
+      <button class="quick-action-btn" @click="$emit('submitCommand', 'help')">
+        ❓ Help
+      </button>
+    </div>
+
+    <!-- Input Bar -->
+    <div class="input-bar">
+      <input
+        v-model="commandInput"
+        type="text"
+        :placeholder="
+          acceptInput ? 'What do you want to do?' : 'Press Enter to continue'
+        "
+        :readonly="!acceptInput"
+        :class="{ 'input-accept-off': !acceptInput }"
+        autocomplete="off"
+        autocapitalize="off"
+        spellcheck="false"
+        autofocus
+        @keydown.enter="acceptInput ? onKeyEnter() : $emit('advanceTurn')"
+      />
+      <button class="send-btn" :disabled="!acceptInput" @click="onSendClick()">
+        Send
+      </button>
+    </div>
+  </div>
+</template>

--- a/web/src/components/ContextMenu.vue
+++ b/web/src/components/ContextMenu.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+export interface MenuAction {
+  label: string
+  command: string
+}
+
+defineProps<{
+  visible: boolean
+  target: string
+  actions: MenuAction[]
+  x: number
+  y: number
+}>()
+
+defineEmits<{
+  close: []
+  executeAction: [action: MenuAction]
+}>()
+</script>
+
+<template>
+  <div v-if="visible">
+    <div
+      style="position: fixed; inset: 0; z-index: 99"
+      @click="$emit('close')"
+    ></div>
+    <div
+      class="context-menu"
+      :style="`left:${x}px;top:${y}px`"
+      @keydown.escape="$emit('close')"
+    >
+      <div class="context-menu-header">{{ target }}</div>
+      <div
+        v-for="action in actions"
+        :key="action.label"
+        class="context-menu-item"
+        @click="$emit('executeAction', action)"
+      >
+        {{ action.label }}
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/components/GameLayout.vue
+++ b/web/src/components/GameLayout.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { NamedItem } from '@/types/bridge'
+import type { MenuAction } from './ContextMenu.vue'
+import TopBar from './TopBar.vue'
+import GameOutput from './GameOutput.vue'
+import CommandInput from './CommandInput.vue'
+import SidePanel from './SidePanel.vue'
+import ContextMenu from './ContextMenu.vue'
+import ActionSheet from './ActionSheet.vue'
+import MobileDrawer from './MobileDrawer.vue'
+import QuestModal from './QuestModal.vue'
+
+// Placeholder state — will be replaced by Pinia stores in #50
+const musicMuted = ref(false)
+const acceptInput = ref(true)
+const showDrawer = ref(false)
+const showContextMenu = ref(false)
+const showActionSheet = ref(false)
+const showModal = ref(false)
+
+const roomName = ref('Village Square')
+const roomDescription = ref('A peaceful village center with a well.')
+const characters = ref<string[]>(['Mira', 'Merchant'])
+const items = ref<string[]>(['Old Map'])
+const exits = ref<Record<string, string>>({
+  north: 'Forest Path',
+  south: 'Village Gate',
+})
+const lastOutput = ref('')
+const introText = ref('Welcome to RetroQuest!')
+
+const activeQuests = ref<NamedItem[]>([])
+const completedQuests = ref<NamedItem[]>([])
+const inventory = ref<NamedItem[]>([])
+const spells = ref<NamedItem[]>([])
+
+const showActiveQuests = ref(true)
+const showCompletedQuests = ref(false)
+const showInventory = ref(true)
+const showSpells = ref(true)
+
+const contextMenuTarget = ref('')
+const contextMenuActions = ref<MenuAction[]>([])
+const contextMenuX = ref(0)
+const contextMenuY = ref(0)
+
+const actionSheetTarget = ref('')
+const actionSheetActions = ref<MenuAction[]>([])
+
+const modalTitle = ref('')
+const modalBody = ref('')
+
+function toggleSection(section: string) {
+  const map: Record<string, typeof showActiveQuests> = {
+    activeQuests: showActiveQuests,
+    completedQuests: showCompletedQuests,
+    inventory: showInventory,
+    spells: showSpells,
+  }
+  const toggle = map[section]
+  if (toggle) toggle.value = !toggle.value
+}
+
+function closeMenus() {
+  showContextMenu.value = false
+  showActionSheet.value = false
+}
+</script>
+
+<template>
+  <div style="display: flex; flex-direction: column; height: 100vh">
+    <TopBar
+      title="RetroQuest"
+      :music-muted="musicMuted"
+      @save="() => {}"
+      @load="() => {}"
+      @toggle-mute="musicMuted = !musicMuted"
+      @help="() => {}"
+      @toggle-drawer="showDrawer = !showDrawer"
+    />
+
+    <div class="app-layout">
+      <GameOutput
+        :room-name="roomName"
+        :room-description="roomDescription"
+        :characters="characters"
+        :items="items"
+        :exits="exits"
+        :last-output="lastOutput"
+        :intro-text="introText"
+        @entity-click="() => {}"
+        @go-direction="() => {}"
+      />
+
+      <SidePanel
+        :active-quests="activeQuests"
+        :completed-quests="completedQuests"
+        :inventory="inventory"
+        :spells="spells"
+        :show-active-quests="showActiveQuests"
+        :show-completed-quests="showCompletedQuests"
+        :show-inventory="showInventory"
+        :show-spells="showSpells"
+        @toggle-section="toggleSection"
+        @inventory-click="() => {}"
+        @spell-click="() => {}"
+      />
+    </div>
+
+    <CommandInput
+      :accept-input="acceptInput"
+      @submit-command="() => {}"
+      @advance-turn="() => {}"
+    />
+
+    <ContextMenu
+      :visible="showContextMenu"
+      :target="contextMenuTarget"
+      :actions="contextMenuActions"
+      :x="contextMenuX"
+      :y="contextMenuY"
+      @close="closeMenus"
+      @execute-action="() => {}"
+    />
+
+    <ActionSheet
+      :visible="showActionSheet"
+      :target="actionSheetTarget"
+      :actions="actionSheetActions"
+      @close="closeMenus"
+      @execute-action="() => {}"
+    />
+
+    <MobileDrawer
+      :visible="showDrawer"
+      :active-quests="activeQuests"
+      :inventory="inventory"
+      :spells="spells"
+      @close="showDrawer = false"
+      @inventory-click="() => {}"
+      @spell-click="() => {}"
+    />
+
+    <QuestModal
+      :visible="showModal"
+      :title="modalTitle"
+      :body="modalBody"
+      @dismiss="showModal = false"
+    />
+  </div>
+</template>

--- a/web/src/components/GameOutput.vue
+++ b/web/src/components/GameOutput.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+defineProps<{
+  roomName: string
+  roomDescription: string
+  characters: string[]
+  items: string[]
+  exits: Record<string, string>
+  lastOutput: string
+  introText: string
+}>()
+
+defineEmits<{
+  entityClick: [event: MouseEvent, name: string, type: string]
+  goDirection: [direction: string]
+}>()
+
+function getArrow(direction: string): string {
+  const arrows: Record<string, string> = {
+    north: '↑',
+    south: '↓',
+    east: '→',
+    west: '←',
+    up: '⬆',
+    down: '⬇',
+  }
+  return arrows[direction.toLowerCase()] ?? '•'
+}
+</script>
+
+<template>
+  <div class="main-content">
+    <!-- Room Card -->
+    <div class="room-card">
+      <div class="room-name">{{ roomName }}</div>
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <div class="room-description" v-html="roomDescription"></div>
+
+      <!-- Characters -->
+      <div v-if="characters.length > 0" class="entity-section">
+        <div class="entity-label">Characters</div>
+        <div class="chip-row">
+          <button
+            v-for="char in characters"
+            :key="char"
+            class="chip chip-character"
+            @click="$emit('entityClick', $event, char, 'character')"
+          >
+            👤 {{ char }}
+          </button>
+        </div>
+      </div>
+
+      <!-- Items -->
+      <div v-if="items.length > 0" class="entity-section">
+        <div class="entity-label">Items</div>
+        <div class="chip-row">
+          <button
+            v-for="item in items"
+            :key="item"
+            class="chip chip-item"
+            @click="$emit('entityClick', $event, item, 'item')"
+          >
+            📦 {{ item }}
+          </button>
+        </div>
+      </div>
+
+      <!-- Exits -->
+      <div v-if="Object.keys(exits).length > 0" class="entity-section">
+        <div class="entity-label">Exits</div>
+        <div class="chip-row">
+          <button
+            v-for="[dir, dest] in Object.entries(exits)"
+            :key="dir"
+            class="chip chip-exit"
+            @click="$emit('goDirection', dir)"
+          >
+            {{ getArrow(dir) }} {{ dir }}
+            <span style="opacity: 0.6; font-size: 0.8em">({{ dest }})</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Result Area -->
+    <div class="result-area">
+      <!-- eslint-disable vue/no-v-html -->
+      <div
+        v-if="lastOutput || introText"
+        class="result-content"
+        v-html="lastOutput || introText"
+      ></div>
+      <!-- eslint-enable vue/no-v-html -->
+    </div>
+  </div>
+</template>

--- a/web/src/components/MobileDrawer.vue
+++ b/web/src/components/MobileDrawer.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import type { NamedItem } from '@/types/bridge'
+
+defineProps<{
+  visible: boolean
+  activeQuests: NamedItem[]
+  inventory: NamedItem[]
+  spells: NamedItem[]
+}>()
+
+defineEmits<{
+  close: []
+  inventoryClick: [event: MouseEvent, name: string]
+  spellClick: [event: MouseEvent, name: string]
+}>()
+</script>
+
+<template>
+  <div v-if="visible">
+    <div class="drawer-scrim" @click="$emit('close')"></div>
+    <div class="drawer">
+      <div class="drawer-header">
+        <span style="font-weight: 700; font-size: 1rem">Menu</span>
+        <button
+          class="drawer-close-btn"
+          aria-label="Close menu"
+          @click="$emit('close')"
+        >
+          ✕
+        </button>
+      </div>
+
+      <!-- Active Quests -->
+      <div class="sidebar-section">
+        <div class="sidebar-section-title">📜 Active Quests</div>
+        <div v-if="activeQuests.length === 0" class="sidebar-empty">
+          No active quests
+        </div>
+        <div
+          v-for="quest in activeQuests"
+          :key="quest.name"
+          class="sidebar-item"
+        >
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="sidebar-item-name" v-html="quest.name"></div>
+          <div class="sidebar-item-desc">{{ quest.description }}</div>
+        </div>
+      </div>
+
+      <!-- Inventory -->
+      <div class="sidebar-section">
+        <div class="sidebar-section-title">🎒 Inventory</div>
+        <div v-if="inventory.length === 0" class="sidebar-empty">
+          Inventory is empty
+        </div>
+        <div
+          v-for="item in inventory"
+          :key="item.name"
+          class="sidebar-item sidebar-clickable"
+          @click="$emit('inventoryClick', $event, item.name)"
+        >
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="sidebar-item-name" v-html="item.name"></div>
+          <div class="sidebar-item-desc">{{ item.description }}</div>
+        </div>
+      </div>
+
+      <!-- Spells -->
+      <div class="sidebar-section">
+        <div class="sidebar-section-title">✨ Spells</div>
+        <div v-if="spells.length === 0" class="sidebar-empty">
+          No spells known
+        </div>
+        <div
+          v-for="spell in spells"
+          :key="spell.name"
+          class="sidebar-item sidebar-clickable"
+          @click="$emit('spellClick', $event, spell.name)"
+        >
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="sidebar-item-name" v-html="spell.name"></div>
+          <div class="sidebar-item-desc">{{ spell.description }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/components/QuestModal.vue
+++ b/web/src/components/QuestModal.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+defineProps<{
+  visible: boolean
+  title: string
+  body: string
+}>()
+
+defineEmits<{
+  dismiss: []
+}>()
+</script>
+
+<template>
+  <div v-if="visible" class="modal-overlay" @click.self="$emit('dismiss')">
+    <div class="modal-content">
+      <div class="modal-title">{{ title }}</div>
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <div class="modal-body" v-html="body"></div>
+      <button class="modal-dismiss-btn" @click="$emit('dismiss')">
+        Continue
+      </button>
+      <div style="clear: both"></div>
+    </div>
+  </div>
+</template>

--- a/web/src/components/SidePanel.vue
+++ b/web/src/components/SidePanel.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import type { NamedItem } from '@/types/bridge'
+
+defineProps<{
+  activeQuests: NamedItem[]
+  completedQuests: NamedItem[]
+  inventory: NamedItem[]
+  spells: NamedItem[]
+  showActiveQuests: boolean
+  showCompletedQuests: boolean
+  showInventory: boolean
+  showSpells: boolean
+}>()
+
+defineEmits<{
+  toggleSection: [section: string]
+  inventoryClick: [event: MouseEvent, name: string]
+  spellClick: [event: MouseEvent, name: string]
+}>()
+</script>
+
+<template>
+  <div class="sidebar">
+    <!-- Active Quests -->
+    <div class="sidebar-section">
+      <div
+        class="sidebar-section-title"
+        @click="$emit('toggleSection', 'activeQuests')"
+      >
+        📜 Active Quests
+        <span class="toggle-icon" :class="{ collapsed: !showActiveQuests }"
+          >▼</span
+        >
+      </div>
+      <div v-if="showActiveQuests">
+        <div v-if="activeQuests.length === 0" class="sidebar-empty">
+          No active quests
+        </div>
+        <div
+          v-for="quest in activeQuests"
+          :key="quest.name"
+          class="sidebar-item"
+        >
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="sidebar-item-name" v-html="quest.name"></div>
+          <div class="sidebar-item-desc">{{ quest.description }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Completed Quests -->
+    <div class="sidebar-section">
+      <div
+        class="sidebar-section-title"
+        @click="$emit('toggleSection', 'completedQuests')"
+      >
+        🏆 Completed Quests
+        <span class="toggle-icon" :class="{ collapsed: !showCompletedQuests }"
+          >▼</span
+        >
+      </div>
+      <div v-if="showCompletedQuests">
+        <div v-if="completedQuests.length === 0" class="sidebar-empty">
+          No completed quests
+        </div>
+        <div
+          v-for="quest in completedQuests"
+          :key="quest.name"
+          class="sidebar-item"
+        >
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="sidebar-item-name" v-html="quest.name"></div>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="sidebar-item-desc" v-html="quest.description"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Inventory -->
+    <div class="sidebar-section">
+      <div
+        class="sidebar-section-title"
+        @click="$emit('toggleSection', 'inventory')"
+      >
+        🎒 Inventory
+        <span class="toggle-icon" :class="{ collapsed: !showInventory }"
+          >▼</span
+        >
+      </div>
+      <div v-if="showInventory">
+        <div v-if="inventory.length === 0" class="sidebar-empty">
+          Inventory is empty
+        </div>
+        <div
+          v-for="item in inventory"
+          :key="item.name"
+          class="sidebar-item sidebar-clickable"
+          @click="$emit('inventoryClick', $event, item.name)"
+        >
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="sidebar-item-name" v-html="item.name"></div>
+          <div class="sidebar-item-desc">{{ item.description }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Spells -->
+    <div class="sidebar-section">
+      <div
+        class="sidebar-section-title"
+        @click="$emit('toggleSection', 'spells')"
+      >
+        ✨ Spells
+        <span class="toggle-icon" :class="{ collapsed: !showSpells }">▼</span>
+      </div>
+      <div v-if="showSpells">
+        <div v-if="spells.length === 0" class="sidebar-empty">
+          No spells known
+        </div>
+        <div
+          v-for="spell in spells"
+          :key="spell.name"
+          class="sidebar-item sidebar-clickable"
+          @click="$emit('spellClick', $event, spell.name)"
+        >
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="sidebar-item-name" v-html="spell.name"></div>
+          <div class="sidebar-item-desc">{{ spell.description }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/components/TopBar.vue
+++ b/web/src/components/TopBar.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+defineProps<{
+  title: string
+  musicMuted: boolean
+}>()
+
+defineEmits<{
+  save: []
+  load: []
+  toggleMute: []
+  help: []
+  toggleDrawer: []
+}>()
+</script>
+
+<template>
+  <div class="top-bar">
+    <span class="top-bar-title">⚔️ RetroQuest</span>
+    <div style="display: flex; align-items: center; gap: 8px">
+      <div class="top-bar-actions">
+        <button @click="$emit('save')">💾 Save</button>
+        <button @click="$emit('load')">📂 Load</button>
+        <button
+          :title="musicMuted ? 'Unmute music' : 'Mute music'"
+          :aria-label="musicMuted ? 'Unmute music' : 'Mute music'"
+          @click="$emit('toggleMute')"
+        >
+          {{ musicMuted ? '🔇' : '🎵' }}
+        </button>
+        <button @click="$emit('help')">❓ Help</button>
+      </div>
+      <button
+        class="hamburger-btn"
+        aria-label="Open sidebar"
+        @click="$emit('toggleDrawer')"
+      >
+        ☰
+      </button>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

Creates the complete Vue 3 component structure for the RetroQuest web frontend, splitting the monolithic index.html into discrete, typed SFC components.

## Components Created

| Component | Purpose |
|-----------|---------|
| **TopBar.vue** | App title, save/load/mute/help buttons, mobile hamburger |
| **GameOutput.vue** | Room card (name, description, character/item/exit chips) + result area |
| **CommandInput.vue** | Quick action buttons + text input with keyboard/click handling |
| **SidePanel.vue** | Desktop sidebar with collapsible quest/inventory/spell sections |
| **ContextMenu.vue** | Desktop right-click context menu (exports `MenuAction` type) |
| **ActionSheet.vue** | Mobile bottom sheet for entity actions |
| **MobileDrawer.vue** | Slide-out mobile sidebar with quests/inventory/spells |
| **QuestModal.vue** | Overlay modal for quest activation/completion events |
| **GameLayout.vue** | Root layout composing all components with placeholder state |

## Other Changes

- **App.vue** — updated to render `<GameLayout />`
- **eslint.config.js** — added `globals.browser` for Vue SFCs (fixes `MouseEvent` not-defined errors)
- **package.json** — added `globals` dev dependency

## Checklist

- [x] All components typed with `defineProps`/`defineEmits`
- [x] ESLint clean (0 errors)
- [x] TypeScript type-check passes
- [x] 61 existing tests pass
- [x] Prettier formatted

Closes #46
