### PR TITLE
feat(#47): migrate game state to Pinia store

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "retroquest-web",
       "version": "1.0.0",
+      "dependencies": {
+        "pinia": "^3.0.4"
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.6.0",
@@ -29,7 +32,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -39,7 +41,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -49,7 +50,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -65,7 +65,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -307,7 +306,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1081,7 +1079,6 @@
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
       "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
@@ -1095,14 +1092,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
       "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-core": "3.5.32",
@@ -1113,7 +1108,6 @@
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
       "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
@@ -1131,18 +1125,49 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
       "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-dom": "3.5.32",
         "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
       }
     },
     "node_modules/@vue/language-core": {
@@ -1165,7 +1190,6 @@
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
       "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/shared": "3.5.32"
@@ -1175,7 +1199,6 @@
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
       "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/reactivity": "3.5.32",
@@ -1186,7 +1209,6 @@
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
       "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/reactivity": "3.5.32",
@@ -1199,7 +1221,6 @@
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
       "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-ssr": "3.5.32",
@@ -1213,7 +1234,6 @@
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
       "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vue/tsconfig": {
@@ -1302,6 +1322,15 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1339,6 +1368,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1371,7 +1415,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1413,7 +1456,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -1793,6 +1835,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -1834,6 +1882,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/isexe": {
@@ -2181,7 +2241,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -2203,6 +2262,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2221,7 +2286,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2351,11 +2415,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2371,11 +2440,31 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pinia": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^7.7.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.5.0",
+        "vue": "^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2449,6 +2538,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
@@ -2538,7 +2633,15 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2557,6 +2660,18 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2640,7 +2755,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -2877,7 +2992,6 @@
       "version": "3.5.32",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
       "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-dom": "3.5.32",

--- a/web/package.json
+++ b/web/package.json
@@ -29,5 +29,8 @@
     "vitest": "^4.1.4",
     "vue": "^3.5.32",
     "vue-tsc": "^3.2.7"
+  },
+  "dependencies": {
+    "pinia": "^3.0.4"
   }
 }

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,5 +1,7 @@
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import App from './App.vue'
 
 const app = createApp(App)
+app.use(createPinia())
 app.mount('#app')

--- a/web/src/stores/useGameStore.test.ts
+++ b/web/src/stores/useGameStore.test.ts
@@ -1,0 +1,457 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useGameStore } from './useGameStore'
+import { renderMarkup } from '@/utils/theme'
+
+vi.mock('@/utils/theme', () => ({
+  renderMarkup: vi.fn((s: string) => `<rendered>${s}</rendered>`),
+}))
+
+/**
+ * Minimal mock matching the useBridge() return shape.
+ */
+function createMockBridge() {
+  return {
+    init: vi.fn(),
+    isReady: vi.fn(() => true),
+    startGame: vi.fn(() => 'Game started'),
+    advanceToRunning: vi.fn(() => ['Intro text']),
+    handleCommand: vi.fn(() => 'command result'),
+    getRoom: vi.fn(() => 'Room'),
+    getRoomName: vi.fn(() => 'Village Square'),
+    getRoomDescription: vi.fn(() => 'A quiet village.'),
+    getRoomCharacters: vi.fn(() => ['Mira']),
+    getRoomItems: vi.fn(() => ['Map']),
+    getRoomExits: vi.fn(() => ({ north: 'Forest' }) as Record<string, string>),
+    getInventory: vi.fn(() => [{ name: 'Sword', description: 'Sharp' }]),
+    getSpells: vi.fn(() => [{ name: 'Heal', description: 'Restores HP' }]),
+    getActiveQuests: vi.fn(() => [
+      { name: 'Find Key', description: 'Find the key' },
+    ]),
+    getCompletedQuests: vi.fn(
+      () => [] as { name: string; description: string }[],
+    ),
+    activateQuest: vi.fn((): string | null => null),
+    updateQuest: vi.fn((): string | null => null),
+    completeQuest: vi.fn((): string | null => null),
+    look: vi.fn(() => 'You look around'),
+    getActIntro: vi.fn(() => 'Act intro'),
+    saveGame: vi.fn(() => 'Game saved.'),
+    loadGame: vi.fn(() => 'Game loaded.'),
+    isAcceptingInput: vi.fn(() => true),
+    advanceTurn: vi.fn(() => 'Turn advanced'),
+    isGameRunning: vi.fn(() => true),
+    isActRunning: vi.fn(() => true),
+    getMusicInfo: vi.fn(() => ({
+      musicFile: 'track.mp3',
+      musicInfo: 'Track info',
+    })),
+  }
+}
+
+type MockBridge = ReturnType<typeof createMockBridge>
+
+describe('useGameStore', () => {
+  let store: ReturnType<typeof useGameStore>
+  let bridge: MockBridge
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    bridge = createMockBridge()
+    store = useGameStore()
+    store.setBridge(bridge as never)
+  })
+
+  // --- Initial state ---
+
+  describe('initial state', () => {
+    it('starts with loading true', () => {
+      expect(store.loading).toBe(true)
+    })
+
+    it('has empty room data', () => {
+      expect(store.roomName).toBe('')
+      expect(store.roomDescription).toBe('')
+      expect(store.characters).toEqual([])
+      expect(store.items).toEqual([])
+      expect(store.exits).toEqual({})
+    })
+
+    it('has empty panel data', () => {
+      expect(store.inventory).toEqual([])
+      expect(store.spells).toEqual([])
+      expect(store.activeQuests).toEqual([])
+      expect(store.completedQuests).toEqual([])
+    })
+
+    it('has empty output', () => {
+      expect(store.lastOutput).toBe('')
+      expect(store.introText).toBe('')
+    })
+
+    it('does not accept input initially', () => {
+      expect(store.acceptInput).toBe(false)
+    })
+
+    it('has sidebar sections visible by default', () => {
+      expect(store.showActiveQuests).toBe(true)
+      expect(store.showCompletedQuests).toBe(false)
+      expect(store.showInventory).toBe(true)
+      expect(store.showSpells).toBe(true)
+    })
+
+    it('has modal hidden', () => {
+      expect(store.showModal).toBe(false)
+      expect(store.modalTitle).toBe('')
+      expect(store.modalBody).toBe('')
+    })
+  })
+
+  // --- initGame ---
+
+  describe('initGame', () => {
+    it('calls bridge.init with progress callback', async () => {
+      await store.initGame()
+      expect(bridge.init).toHaveBeenCalledWith(expect.any(Function))
+    })
+
+    it('sets loading to false after init', async () => {
+      await store.initGame()
+      expect(store.loading).toBe(false)
+    })
+
+    it('updates loadingStatus via progress callback', async () => {
+      bridge.init.mockImplementation(async (cb: (s: string) => void) => {
+        cb('Loading Python...')
+      })
+      await store.initGame()
+      expect(store.loadingStatus).toBe('Loading Python...')
+    })
+
+    it('renders intro text from advanceTurn', async () => {
+      bridge.advanceTurn.mockReturnValue('Welcome!')
+      await store.initGame()
+      expect(store.introText).toBe('<rendered>Welcome!</rendered>')
+      expect(renderMarkup).toHaveBeenCalledWith('Welcome!')
+    })
+
+    it('refreshes panels after init', async () => {
+      await store.initGame()
+      expect(store.roomName).toBe('Village Square')
+      expect(store.characters).toEqual(['Mira'])
+      expect(store.inventory).toEqual([{ name: 'Sword', description: 'Sharp' }])
+    })
+
+    it('syncs acceptInput from bridge', async () => {
+      bridge.isAcceptingInput.mockReturnValue(false)
+      await store.initGame()
+      expect(store.acceptInput).toBe(false)
+    })
+
+    it('sets loadingStatus to error on failure', async () => {
+      bridge.init.mockRejectedValue(new Error('Network error'))
+      await store.initGame()
+      expect(store.loadingStatus).toBe('Error: Network error')
+      expect(store.loading).toBe(true)
+    })
+  })
+
+  // --- submitCommand ---
+
+  describe('submitCommand', () => {
+    beforeEach(async () => {
+      await store.initGame()
+    })
+
+    it('calls bridge.handleCommand with trimmed input', () => {
+      store.submitCommand('  look  ')
+      expect(bridge.handleCommand).toHaveBeenCalledWith('look')
+    })
+
+    it('updates lastOutput with rendered result', () => {
+      bridge.handleCommand.mockReturnValue('You see a forest.')
+      store.submitCommand('look')
+      expect(store.lastOutput).toBe('<rendered>You see a forest.</rendered>')
+    })
+
+    it('refreshes panels after command', () => {
+      bridge.getRoomName.mockReturnValue('Forest Path')
+      store.submitCommand('go north')
+      expect(store.roomName).toBe('Forest Path')
+    })
+
+    it('ignores empty commands', () => {
+      store.submitCommand('')
+      expect(bridge.handleCommand).not.toHaveBeenCalled()
+    })
+
+    it('ignores whitespace-only commands', () => {
+      store.submitCommand('   ')
+      expect(bridge.handleCommand).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when acceptInput is false', () => {
+      store.acceptInput = false
+      store.submitCommand('look')
+      expect(bridge.handleCommand).not.toHaveBeenCalled()
+    })
+
+    it('polls quest events after command', () => {
+      bridge.activateQuest
+        .mockReturnValueOnce('New quest activated!')
+        .mockReturnValueOnce(null)
+      bridge.updateQuest.mockReturnValue(null)
+      bridge.completeQuest.mockReturnValue(null)
+      store.submitCommand('talk to mira')
+      expect(store.showModal).toBe(true)
+      expect(store.modalTitle).toBe('📜 New Quest!')
+    })
+  })
+
+  // --- advanceTurn ---
+
+  describe('advanceTurn', () => {
+    beforeEach(async () => {
+      await store.initGame()
+    })
+
+    it('calls bridge.advanceTurn and renders output', () => {
+      bridge.advanceTurn.mockReturnValue('Act 2 begins...')
+      store.advanceTurn()
+      expect(store.lastOutput).toBe('<rendered>Act 2 begins...</rendered>')
+    })
+
+    it('refreshes panels', () => {
+      bridge.getRoomName.mockReturnValue('Castle Gate')
+      store.advanceTurn()
+      expect(store.roomName).toBe('Castle Gate')
+    })
+  })
+
+  // --- refreshPanels ---
+
+  describe('refreshPanels', () => {
+    beforeEach(async () => {
+      await store.initGame()
+    })
+
+    it('updates all room data', () => {
+      bridge.getRoomName.mockReturnValue('Dungeon')
+      bridge.getRoomDescription.mockReturnValue('Dark place.')
+      bridge.getRoomCharacters.mockReturnValue(['Guard'])
+      bridge.getRoomItems.mockReturnValue(['Key'])
+      bridge.getRoomExits.mockReturnValue({ south: 'Exit' })
+      store.refreshPanels()
+      expect(store.roomName).toBe('Dungeon')
+      expect(store.roomDescription).toBe('Dark place.')
+      expect(store.characters).toEqual(['Guard'])
+      expect(store.items).toEqual(['Key'])
+      expect(store.exits).toEqual({ south: 'Exit' })
+    })
+
+    it('updates inventory and spells', () => {
+      bridge.getInventory.mockReturnValue([
+        { name: 'Potion', description: 'Heals' },
+      ])
+      bridge.getSpells.mockReturnValue([{ name: 'Fire', description: 'Burns' }])
+      store.refreshPanels()
+      expect(store.inventory).toEqual([
+        { name: 'Potion', description: 'Heals' },
+      ])
+      expect(store.spells).toEqual([{ name: 'Fire', description: 'Burns' }])
+    })
+
+    it('updates quests', () => {
+      bridge.getActiveQuests.mockReturnValue([
+        { name: 'Quest A', description: 'Do A' },
+      ])
+      bridge.getCompletedQuests.mockReturnValue([
+        { name: 'Quest B', description: 'Did B' },
+      ])
+      store.refreshPanels()
+      expect(store.activeQuests).toEqual([
+        { name: 'Quest A', description: 'Do A' },
+      ])
+      expect(store.completedQuests).toEqual([
+        { name: 'Quest B', description: 'Did B' },
+      ])
+    })
+
+    it('syncs acceptInput', () => {
+      bridge.isAcceptingInput.mockReturnValue(false)
+      store.refreshPanels()
+      expect(store.acceptInput).toBe(false)
+    })
+  })
+
+  // --- saveGame / loadGame ---
+
+  describe('saveGame', () => {
+    beforeEach(async () => {
+      await store.initGame()
+    })
+
+    it('calls bridge.saveGame and renders output', () => {
+      bridge.saveGame.mockReturnValue('Saved!')
+      store.saveGame()
+      expect(store.lastOutput).toBe('<rendered>Saved!</rendered>')
+    })
+  })
+
+  describe('loadGame', () => {
+    beforeEach(async () => {
+      await store.initGame()
+    })
+
+    it('calls bridge.loadGame and renders output', () => {
+      bridge.loadGame.mockReturnValue('Loaded!')
+      store.loadGame()
+      expect(store.lastOutput).toBe('<rendered>Loaded!</rendered>')
+    })
+
+    it('refreshes panels after loading', () => {
+      bridge.getRoomName.mockReturnValue('Saved Room')
+      store.loadGame()
+      expect(store.roomName).toBe('Saved Room')
+    })
+  })
+
+  // --- pollQuestEvents ---
+
+  describe('pollQuestEvents', () => {
+    beforeEach(async () => {
+      await store.initGame()
+    })
+
+    it('shows modal for activated quest', () => {
+      bridge.activateQuest
+        .mockReturnValueOnce('Quest: Find the gem')
+        .mockReturnValueOnce(null)
+      bridge.updateQuest.mockReturnValue(null)
+      bridge.completeQuest.mockReturnValue(null)
+      store.pollQuestEvents()
+      expect(store.showModal).toBe(true)
+      expect(store.modalTitle).toBe('📜 New Quest!')
+      expect(store.modalBody).toBe('<rendered>Quest: Find the gem</rendered>')
+    })
+
+    it('shows modal for updated quest', () => {
+      bridge.activateQuest.mockReturnValue(null)
+      bridge.updateQuest
+        .mockReturnValueOnce('Quest updated: progress')
+        .mockReturnValueOnce(null)
+      bridge.completeQuest.mockReturnValue(null)
+      store.pollQuestEvents()
+      expect(store.modalTitle).toBe('📜 Quest Updated')
+    })
+
+    it('shows modal for completed quest', () => {
+      bridge.activateQuest.mockReturnValue(null)
+      bridge.updateQuest.mockReturnValue(null)
+      bridge.completeQuest
+        .mockReturnValueOnce('Quest complete!')
+        .mockReturnValueOnce(null)
+      store.pollQuestEvents()
+      expect(store.modalTitle).toBe('🏆 Quest Complete!')
+    })
+
+    it('queues multiple events and shows first', () => {
+      bridge.activateQuest
+        .mockReturnValueOnce('Quest A')
+        .mockReturnValueOnce('Quest B')
+        .mockReturnValueOnce(null)
+      bridge.updateQuest.mockReturnValue(null)
+      bridge.completeQuest.mockReturnValue(null)
+      store.pollQuestEvents()
+      expect(store.modalTitle).toBe('📜 New Quest!')
+      expect(store.modalBody).toBe('<rendered>Quest A</rendered>')
+    })
+
+    it('dismissModal advances to next queued event', () => {
+      bridge.activateQuest
+        .mockReturnValueOnce('Quest A')
+        .mockReturnValueOnce('Quest B')
+        .mockReturnValueOnce(null)
+      bridge.updateQuest.mockReturnValue(null)
+      bridge.completeQuest.mockReturnValue(null)
+      store.pollQuestEvents()
+      store.dismissModal()
+      expect(store.modalBody).toBe('<rendered>Quest B</rendered>')
+    })
+
+    it('dismissModal hides modal when queue empty', () => {
+      bridge.activateQuest
+        .mockReturnValueOnce('Quest A')
+        .mockReturnValueOnce(null)
+      bridge.updateQuest.mockReturnValue(null)
+      bridge.completeQuest.mockReturnValue(null)
+      store.pollQuestEvents()
+      store.dismissModal()
+      expect(store.showModal).toBe(false)
+    })
+
+    it('does nothing when no events', () => {
+      bridge.activateQuest.mockReturnValue(null)
+      bridge.updateQuest.mockReturnValue(null)
+      bridge.completeQuest.mockReturnValue(null)
+      store.pollQuestEvents()
+      expect(store.showModal).toBe(false)
+    })
+  })
+
+  // --- toggleSection ---
+
+  describe('toggleSection', () => {
+    it('toggles activeQuests', () => {
+      expect(store.showActiveQuests).toBe(true)
+      store.toggleSection('activeQuests')
+      expect(store.showActiveQuests).toBe(false)
+      store.toggleSection('activeQuests')
+      expect(store.showActiveQuests).toBe(true)
+    })
+
+    it('toggles completedQuests', () => {
+      expect(store.showCompletedQuests).toBe(false)
+      store.toggleSection('completedQuests')
+      expect(store.showCompletedQuests).toBe(true)
+    })
+
+    it('toggles inventory', () => {
+      store.toggleSection('inventory')
+      expect(store.showInventory).toBe(false)
+    })
+
+    it('toggles spells', () => {
+      store.toggleSection('spells')
+      expect(store.showSpells).toBe(false)
+    })
+
+    it('ignores unknown sections', () => {
+      store.toggleSection('unknown')
+      // No error thrown
+    })
+  })
+
+  // --- getMusicInfo (returned from refreshPanels) ---
+
+  describe('music info from refreshPanels', () => {
+    beforeEach(async () => {
+      await store.initGame()
+    })
+
+    it('exposes musicFile and musicInfo', () => {
+      expect(store.musicFile).toBe('track.mp3')
+      expect(store.musicInfo).toBe('Track info')
+    })
+
+    it('updates on refresh', () => {
+      bridge.getMusicInfo.mockReturnValue({
+        musicFile: 'new.mp3',
+        musicInfo: 'New info',
+      })
+      store.refreshPanels()
+      expect(store.musicFile).toBe('new.mp3')
+      expect(store.musicInfo).toBe('New info')
+    })
+  })
+})

--- a/web/src/stores/useGameStore.ts
+++ b/web/src/stores/useGameStore.ts
@@ -1,0 +1,258 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type { NamedItem, RoomExits } from '@/types/bridge'
+import { renderMarkup } from '@/utils/theme'
+
+/**
+ * Shape of the bridge object injected via setBridge().
+ * Matches the return type of useBridge().
+ */
+export interface GameBridge {
+  init(onProgress?: (status: string) => void): Promise<void>
+  isReady(): boolean
+  handleCommand(command: string): string
+  getRoomName(): string
+  getRoomDescription(): string
+  getRoomCharacters(): string[]
+  getRoomItems(): string[]
+  getRoomExits(): RoomExits
+  getInventory(): NamedItem[]
+  getSpells(): NamedItem[]
+  getActiveQuests(): NamedItem[]
+  getCompletedQuests(): NamedItem[]
+  activateQuest(): string | null
+  updateQuest(): string | null
+  completeQuest(): string | null
+  saveGame(): string
+  loadGame(): string
+  isAcceptingInput(): boolean
+  advanceTurn(): string
+  getMusicInfo(): { musicFile: string; musicInfo: string }
+}
+
+interface QuestEvent {
+  title: string
+  body: string
+}
+
+export const useGameStore = defineStore('game', () => {
+  // --- Bridge reference ---
+  let bridge: GameBridge | null = null
+
+  // --- Loading ---
+  const loading = ref(true)
+  const loadingStatus = ref('Initializing...')
+
+  // --- Room data ---
+  const roomName = ref('')
+  const roomDescription = ref('')
+  const characters = ref<string[]>([])
+  const items = ref<string[]>([])
+  const exits = ref<RoomExits>({})
+
+  // --- Panels ---
+  const inventory = ref<NamedItem[]>([])
+  const spells = ref<NamedItem[]>([])
+  const activeQuests = ref<NamedItem[]>([])
+  const completedQuests = ref<NamedItem[]>([])
+
+  // --- Output ---
+  const lastOutput = ref('')
+  const introText = ref('')
+
+  // --- Input ---
+  const acceptInput = ref(false)
+
+  // --- Sidebar sections ---
+  const showActiveQuests = ref(true)
+  const showCompletedQuests = ref(false)
+  const showInventory = ref(true)
+  const showSpells = ref(true)
+
+  // --- Modal ---
+  const showModal = ref(false)
+  const modalTitle = ref('')
+  const modalBody = ref('')
+  const modalQueue = ref<QuestEvent[]>([])
+
+  // --- Music (exposed for useMusic composable) ---
+  const musicFile = ref('')
+  const musicInfo = ref('')
+
+  function setBridge(b: GameBridge) {
+    bridge = b
+  }
+
+  function requireBridge(): GameBridge {
+    if (!bridge) throw new Error('Bridge not initialized')
+    return bridge
+  }
+
+  async function initGame(): Promise<void> {
+    try {
+      const b = requireBridge()
+      await b.init((status: string) => {
+        loadingStatus.value = status
+      })
+
+      const introRaw = b.advanceTurn()
+      introText.value = renderMarkup(introRaw)
+      acceptInput.value = b.isAcceptingInput()
+      refreshPanels()
+      loading.value = false
+    } catch (err) {
+      loadingStatus.value = `Error: ${(err as Error).message}`
+    }
+  }
+
+  function submitCommand(cmd: string): void {
+    if (!acceptInput.value) return
+    if (!cmd || !cmd.trim()) return
+
+    const b = requireBridge()
+    const result = b.handleCommand(cmd.trim())
+    lastOutput.value = renderMarkup(result)
+    refreshPanels()
+    pollQuestEvents()
+  }
+
+  function advanceTurn(): void {
+    const b = requireBridge()
+    const result = b.advanceTurn()
+    lastOutput.value = renderMarkup(result)
+    refreshPanels()
+  }
+
+  function refreshPanels(): void {
+    const b = requireBridge()
+    roomName.value = b.getRoomName()
+    roomDescription.value = b.getRoomDescription()
+    characters.value = b.getRoomCharacters()
+    items.value = b.getRoomItems()
+    exits.value = b.getRoomExits()
+    inventory.value = b.getInventory()
+    spells.value = b.getSpells()
+    activeQuests.value = b.getActiveQuests()
+    completedQuests.value = b.getCompletedQuests()
+    const m = b.getMusicInfo()
+    musicFile.value = m.musicFile
+    musicInfo.value = m.musicInfo
+    acceptInput.value = b.isAcceptingInput()
+  }
+
+  function saveGame(): void {
+    const b = requireBridge()
+    const result = b.saveGame()
+    lastOutput.value = renderMarkup(result)
+  }
+
+  function loadGame(): void {
+    const b = requireBridge()
+    const result = b.loadGame()
+    lastOutput.value = renderMarkup(result)
+    refreshPanels()
+  }
+
+  function pollQuestEvents(): void {
+    const b = requireBridge()
+    const events: QuestEvent[] = []
+
+    let activated: string | null
+    while ((activated = b.activateQuest()) !== null) {
+      events.push({
+        title: '📜 New Quest!',
+        body: renderMarkup(activated),
+      })
+    }
+
+    let updated: string | null
+    while ((updated = b.updateQuest()) !== null) {
+      events.push({
+        title: '📜 Quest Updated',
+        body: renderMarkup(updated),
+      })
+    }
+
+    let completed: string | null
+    while ((completed = b.completeQuest()) !== null) {
+      events.push({
+        title: '🏆 Quest Complete!',
+        body: renderMarkup(completed),
+      })
+    }
+
+    if (events.length > 0) {
+      modalQueue.value.push(...events)
+      if (!showModal.value) {
+        showNextModal()
+      }
+    }
+
+    activeQuests.value = b.getActiveQuests()
+    completedQuests.value = b.getCompletedQuests()
+  }
+
+  function showNextModal(): void {
+    if (modalQueue.value.length === 0) {
+      showModal.value = false
+      return
+    }
+    const event = modalQueue.value.shift()!
+    modalTitle.value = event.title
+    modalBody.value = event.body
+    showModal.value = true
+  }
+
+  function dismissModal(): void {
+    showNextModal()
+  }
+
+  function toggleSection(section: string): void {
+    const map: Record<string, typeof showActiveQuests> = {
+      activeQuests: showActiveQuests,
+      completedQuests: showCompletedQuests,
+      inventory: showInventory,
+      spells: showSpells,
+    }
+    const toggle = map[section]
+    if (toggle) toggle.value = !toggle.value
+  }
+
+  return {
+    // State
+    loading,
+    loadingStatus,
+    roomName,
+    roomDescription,
+    characters,
+    items,
+    exits,
+    inventory,
+    spells,
+    activeQuests,
+    completedQuests,
+    lastOutput,
+    introText,
+    acceptInput,
+    showActiveQuests,
+    showCompletedQuests,
+    showInventory,
+    showSpells,
+    showModal,
+    modalTitle,
+    modalBody,
+    musicFile,
+    musicInfo,
+    // Actions
+    setBridge,
+    initGame,
+    submitCommand,
+    advanceTurn,
+    refreshPanels,
+    saveGame,
+    loadGame,
+    pollQuestEvents,
+    dismissModal,
+    toggleSection,
+  }
+})


### PR DESCRIPTION
## Summary

Migrates game state management from the Alpine.js store (`app.js`) to a typed Pinia store, providing reactive state for the Vue 3 frontend.

## Changes

### New files
- **`src/stores/useGameStore.ts`** — Pinia setup store with:
  - `GameBridge` interface for dependency injection (decoupled from `useBridge`)
  - Typed reactive state: room data, panels, output, modal queue, sidebar toggles, music info
  - Actions: `initGame`, `submitCommand`, `advanceTurn`, `refreshPanels`, `saveGame`, `loadGame`, `pollQuestEvents`, `dismissModal`, `toggleSection`
- **`src/stores/useGameStore.test.ts`** — 44 unit tests covering all state transitions

### Modified files
- **`src/main.ts`** — registers Pinia via `app.use(createPinia())`
- **`package.json`** — added `pinia` dependency

## Test coverage

| Area | Tests |
|------|-------|
| Initial state | 7 |
| initGame | 7 |
| submitCommand | 7 |
| advanceTurn | 2 |
| refreshPanels | 4 |
| saveGame / loadGame | 3 |
| pollQuestEvents + modal | 7 |
| toggleSection | 5 |
| musicInfo | 2 |
| **Total** | **44** |

All 105 tests pass (44 store + 28 bridge + 28 theme + 5 plugin).

Closes #47
