### PR TITLE
feat(#49): migrate entity menu logic to useEntityMenu.ts composable

### DIFF
--- a/web/src/composables/useEntityMenu.test.ts
+++ b/web/src/composables/useEntityMenu.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useEntityMenu } from './useEntityMenu'
+
+describe('useEntityMenu', () => {
+  let menu: ReturnType<typeof useEntityMenu>
+  const mockSubmit = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    menu = useEntityMenu(mockSubmit)
+  })
+
+  describe('initial state', () => {
+    it('starts with menu closed', () => {
+      expect(menu.visible.value).toBe(false)
+    })
+
+    it('starts with no target', () => {
+      expect(menu.target.value).toBe('')
+    })
+
+    it('starts with empty actions', () => {
+      expect(menu.actions.value).toEqual([])
+    })
+
+    it('starts with zero position', () => {
+      expect(menu.x.value).toBe(0)
+      expect(menu.y.value).toBe(0)
+    })
+
+    it('starts in desktop mode', () => {
+      expect(menu.isMobile.value).toBe(false)
+    })
+  })
+
+  describe('openMenu — character', () => {
+    const event = { clientX: 150, clientY: 200 } as MouseEvent
+
+    beforeEach(() => {
+      menu.openMenu('character', 'Mira', event)
+    })
+
+    it('opens the menu', () => {
+      expect(menu.visible.value).toBe(true)
+    })
+
+    it('sets the target name', () => {
+      expect(menu.target.value).toBe('Mira')
+    })
+
+    it('positions from mouse event', () => {
+      expect(menu.x.value).toBe(150)
+      expect(menu.y.value).toBe(200)
+    })
+
+    it('provides character actions', () => {
+      const labels = menu.actions.value.map((a) => a.label)
+      expect(labels).toContain('💬 Talk to')
+      expect(labels).toContain('👀 Look at')
+      expect(labels).toContain('🎁 Give item...')
+      expect(labels).toContain('✨ Cast spell...')
+    })
+
+    it('sets talk command with name', () => {
+      const talk = menu.actions.value.find((a) => a.label.includes('Talk'))
+      expect(talk?.command).toBe('talk to Mira')
+    })
+  })
+
+  describe('openMenu — item', () => {
+    const event = { clientX: 100, clientY: 100 } as MouseEvent
+
+    it('provides item actions', () => {
+      menu.openMenu('item', 'Key', event)
+      const labels = menu.actions.value.map((a) => a.label)
+      expect(labels).toContain('✋ Take')
+      expect(labels).toContain('👀 Look at')
+      expect(labels).toContain('🔧 Use')
+    })
+
+    it('sets take command with name', () => {
+      menu.openMenu('item', 'Key', event)
+      const take = menu.actions.value.find((a) => a.label.includes('Take'))
+      expect(take?.command).toBe('take Key')
+    })
+  })
+
+  describe('openMenu — inventory', () => {
+    const event = { clientX: 100, clientY: 100 } as MouseEvent
+
+    it('strips markup tags from name', () => {
+      menu.openMenu('inventory', '[gold]Sword[/gold]', event)
+      expect(menu.target.value).toBe('Sword')
+    })
+
+    it('strips count prefix from name', () => {
+      menu.openMenu('inventory', '3 Arrows', event)
+      expect(menu.target.value).toBe('Arrows')
+    })
+
+    it('provides inventory actions', () => {
+      menu.openMenu('inventory', 'Potion', event)
+      const labels = menu.actions.value.map((a) => a.label)
+      expect(labels).toContain('👀 Look at')
+      expect(labels).toContain('🔧 Use')
+      expect(labels).toContain('🗑️ Drop')
+    })
+  })
+
+  describe('openMenu — spell', () => {
+    const event = { clientX: 100, clientY: 100 } as MouseEvent
+
+    it('strips markup tags from name', () => {
+      menu.openMenu('spell', '[magic]Fireball[/magic]', event)
+      expect(menu.target.value).toBe('Fireball')
+    })
+
+    it('provides spell actions', () => {
+      menu.openMenu('spell', 'Heal', event)
+      const labels = menu.actions.value.map((a) => a.label)
+      expect(labels).toContain('✨ Cast')
+      expect(labels).toContain('👀 Look at')
+    })
+  })
+
+  describe('closeMenu', () => {
+    it('hides the menu', () => {
+      const event = { clientX: 100, clientY: 100 } as MouseEvent
+      menu.openMenu('item', 'Key', event)
+      menu.closeMenu()
+      expect(menu.visible.value).toBe(false)
+    })
+  })
+
+  describe('selectAction — simple command', () => {
+    it('submits the command and closes menu', () => {
+      const event = { clientX: 100, clientY: 100 } as MouseEvent
+      menu.openMenu('item', 'Key', event)
+      menu.selectAction({
+        label: '✋ Take',
+        command: 'take Key',
+      })
+      expect(mockSubmit).toHaveBeenCalledWith('take Key')
+      expect(menu.visible.value).toBe(false)
+    })
+  })
+
+  describe('selectAction — give item (needsItem)', () => {
+    const event = { clientX: 100, clientY: 100 } as MouseEvent
+
+    it('shows sub-menu of inventory items', () => {
+      menu.openMenu('character', 'Mira', event)
+      const inventory = [
+        { name: 'Sword', description: '' },
+        { name: 'Shield', description: '' },
+      ]
+      menu.selectAction(
+        { label: '🎁 Give item...', command: 'give', needsItem: true },
+        inventory,
+        [],
+      )
+      expect(menu.visible.value).toBe(true)
+      expect(menu.actions.value).toHaveLength(2)
+      expect(menu.actions.value[0].command).toBe('give Sword to Mira')
+      expect(menu.actions.value[1].command).toBe('give Shield to Mira')
+    })
+
+    it('shows failure message when inventory is empty', () => {
+      menu.openMenu('character', 'Mira', event)
+      const result = menu.selectAction(
+        { label: '🎁 Give item...', command: 'give', needsItem: true },
+        [],
+        [],
+      )
+      expect(result).toBe('no-items')
+      expect(menu.visible.value).toBe(false)
+    })
+
+    it('strips markup from inventory item names', () => {
+      menu.openMenu('character', 'Mira', event)
+      const inventory = [{ name: '[gold]2 Swords[/gold]', description: '' }]
+      menu.selectAction(
+        { label: '🎁 Give item...', command: 'give', needsItem: true },
+        inventory,
+        [],
+      )
+      expect(menu.actions.value[0].command).toBe('give Swords to Mira')
+    })
+  })
+
+  describe('selectAction — cast spell (needsSpell)', () => {
+    const event = { clientX: 100, clientY: 100 } as MouseEvent
+
+    it('shows sub-menu of spells', () => {
+      menu.openMenu('character', 'Mira', event)
+      const spells = [
+        { name: 'Heal', description: '' },
+        { name: 'Fire', description: '' },
+      ]
+      menu.selectAction(
+        {
+          label: '✨ Cast spell...',
+          command: 'cast',
+          needsSpell: true,
+        },
+        [],
+        spells,
+      )
+      expect(menu.visible.value).toBe(true)
+      expect(menu.actions.value[0].command).toBe('cast Heal on Mira')
+    })
+
+    it('shows failure message when no spells known', () => {
+      menu.openMenu('character', 'Mira', event)
+      const result = menu.selectAction(
+        {
+          label: '✨ Cast spell...',
+          command: 'cast',
+          needsSpell: true,
+        },
+        [],
+        [],
+      )
+      expect(result).toBe('no-spells')
+      expect(menu.visible.value).toBe(false)
+    })
+
+    it('strips markup from spell names', () => {
+      menu.openMenu('character', 'Mira', event)
+      const spells = [{ name: '[magic]Fireball[/magic]', description: '' }]
+      menu.selectAction(
+        {
+          label: '✨ Cast spell...',
+          command: 'cast',
+          needsSpell: true,
+        },
+        [],
+        spells,
+      )
+      expect(menu.actions.value[0].command).toBe('cast Fireball on Mira')
+    })
+  })
+
+  describe('mobile mode', () => {
+    it('can be set to mobile', () => {
+      menu.isMobile.value = true
+      expect(menu.isMobile.value).toBe(true)
+    })
+
+    it('open still sets target and actions in mobile', () => {
+      menu.isMobile.value = true
+      const event = { clientX: 100, clientY: 100 } as MouseEvent
+      menu.openMenu('item', 'Key', event)
+      expect(menu.target.value).toBe('Key')
+      expect(menu.actions.value.length).toBeGreaterThan(0)
+      expect(menu.visible.value).toBe(true)
+    })
+  })
+
+  describe('position clamping', () => {
+    it('clamps x to viewport width minus menu width', () => {
+      const event = {
+        clientX: 9999,
+        clientY: 100,
+      } as MouseEvent
+      menu.openMenu('item', 'Key', event, {
+        viewportWidth: 800,
+        viewportHeight: 600,
+      })
+      expect(menu.x.value).toBe(600) // 800 - 200
+    })
+
+    it('clamps y to viewport height minus menu height', () => {
+      const event = {
+        clientX: 100,
+        clientY: 9999,
+      } as MouseEvent
+      menu.openMenu('item', 'Key', event, {
+        viewportWidth: 800,
+        viewportHeight: 600,
+      })
+      expect(menu.y.value).toBe(350) // 600 - 250
+    })
+  })
+})

--- a/web/src/composables/useEntityMenu.ts
+++ b/web/src/composables/useEntityMenu.ts
@@ -1,0 +1,203 @@
+/** Composable for entity context menu / action sheet interactions. */
+import { ref } from 'vue'
+import type { NamedItem } from '@/types/bridge'
+
+export type EntityType = 'character' | 'item' | 'inventory' | 'spell'
+
+export interface EntityMenuAction {
+  label: string
+  command: string
+  needsItem?: boolean
+  needsSpell?: boolean
+}
+
+export interface ViewportSize {
+  viewportWidth: number
+  viewportHeight: number
+}
+
+const MENU_WIDTH = 200
+const MENU_HEIGHT = 250
+
+/**
+ * Strip markup tags like [gold]...[/gold] from a string.
+ */
+function stripMarkup(text: string): string {
+  return text.replace(/\[.*?\]/g, '').trim()
+}
+
+/**
+ * Strip markup tags and leading count prefix (e.g. "3 Arrows").
+ */
+function cleanInventoryName(text: string): string {
+  return stripMarkup(text).replace(/^\d+\s+/, '')
+}
+
+function actionsForCharacter(name: string): EntityMenuAction[] {
+  return [
+    { label: '💬 Talk to', command: `talk to ${name}` },
+    { label: '👀 Look at', command: `look ${name}` },
+    {
+      label: '🎁 Give item...',
+      command: 'give',
+      needsItem: true,
+    },
+    {
+      label: '✨ Cast spell...',
+      command: 'cast',
+      needsSpell: true,
+    },
+  ]
+}
+
+function actionsForItem(name: string): EntityMenuAction[] {
+  return [
+    { label: '✋ Take', command: `take ${name}` },
+    { label: '👀 Look at', command: `look ${name}` },
+    { label: '🔧 Use', command: `use ${name}` },
+  ]
+}
+
+function actionsForInventory(name: string): EntityMenuAction[] {
+  return [
+    { label: '👀 Look at', command: `look ${name}` },
+    { label: '🔧 Use', command: `use ${name}` },
+    { label: '🗑️ Drop', command: `drop ${name}` },
+  ]
+}
+
+function actionsForSpell(name: string): EntityMenuAction[] {
+  return [
+    { label: '✨ Cast', command: `cast ${name}` },
+    { label: '👀 Look at', command: `look ${name}` },
+  ]
+}
+
+/**
+ * Composable that manages entity context menu state and actions.
+ *
+ * @param submitCommand - Callback invoked when a simple action is
+ *   selected (receives the command string).
+ */
+export function useEntityMenu(submitCommand: (cmd: string) => void) {
+  const visible = ref(false)
+  const target = ref('')
+  const actions = ref<EntityMenuAction[]>([])
+  const x = ref(0)
+  const y = ref(0)
+  const isMobile = ref(false)
+
+  /**
+   * Open menu for a given entity type and name.
+   */
+  function openMenu(
+    type: EntityType,
+    rawName: string,
+    event: MouseEvent,
+    viewport?: ViewportSize,
+  ): void {
+    let name: string
+    let menuActions: EntityMenuAction[]
+
+    switch (type) {
+      case 'character':
+        name = rawName
+        menuActions = actionsForCharacter(name)
+        break
+      case 'item':
+        name = rawName
+        menuActions = actionsForItem(name)
+        break
+      case 'inventory':
+        name = cleanInventoryName(rawName)
+        menuActions = actionsForInventory(name)
+        break
+      case 'spell':
+        name = stripMarkup(rawName)
+        menuActions = actionsForSpell(name)
+        break
+    }
+
+    target.value = name
+    actions.value = menuActions
+    visible.value = true
+
+    const vw =
+      viewport?.viewportWidth ??
+      (typeof window !== 'undefined' ? window.innerWidth : 1024)
+    const vh =
+      viewport?.viewportHeight ??
+      (typeof window !== 'undefined' ? window.innerHeight : 768)
+    x.value = Math.min(event.clientX, vw - MENU_WIDTH)
+    y.value = Math.min(event.clientY, vh - MENU_HEIGHT)
+  }
+
+  /** Close the menu. */
+  function closeMenu(): void {
+    visible.value = false
+  }
+
+  /**
+   * Handle action selection. Simple commands are submitted
+   * directly. Actions with needsItem / needsSpell show a
+   * sub-menu instead.
+   *
+   * @returns 'no-items' | 'no-spells' if the sub-menu cannot
+   *   be shown, undefined otherwise.
+   */
+  function selectAction(
+    action: EntityMenuAction,
+    inventory: NamedItem[] = [],
+    spells: NamedItem[] = [],
+  ): 'no-items' | 'no-spells' | undefined {
+    const savedTarget = target.value
+
+    if (action.needsItem) {
+      closeMenu()
+      if (inventory.length === 0) return 'no-items'
+      const subActions = inventory.map((item) => {
+        const clean = cleanInventoryName(item.name)
+        return {
+          label: `🎁 ${clean}`,
+          command: `give ${clean} to ${savedTarget}`,
+        }
+      })
+      target.value = `Give to ${savedTarget}`
+      actions.value = subActions
+      visible.value = true
+      return undefined
+    }
+
+    if (action.needsSpell) {
+      closeMenu()
+      if (spells.length === 0) return 'no-spells'
+      const subActions = spells.map((spell) => {
+        const clean = stripMarkup(spell.name)
+        return {
+          label: `✨ ${clean}`,
+          command: `cast ${clean} on ${savedTarget}`,
+        }
+      })
+      target.value = `Cast on ${savedTarget}`
+      actions.value = subActions
+      visible.value = true
+      return undefined
+    }
+
+    closeMenu()
+    submitCommand(action.command)
+    return undefined
+  }
+
+  return {
+    visible,
+    target,
+    actions,
+    x,
+    y,
+    isMobile,
+    openMenu,
+    closeMenu,
+    selectAction,
+  }
+}


### PR DESCRIPTION
## Summary

Extracts entity interaction / context menu logic from `app.js` into a dedicated `useEntityMenu.ts` composable, replacing three duplicated click handlers with a single unified `openMenu()` flow.

## New files

- **`src/composables/useEntityMenu.ts`** — Entity menu composable with:
  - `openMenu(type, name, event, viewport?)` — unified handler for character, item, inventory, spell clicks
  - `selectAction(action, inventory?, spells?)` — handles simple commands and give-item / cast-spell sub-menus
  - `closeMenu()` — resets visibility
  - Reactive state: `visible`, `target`, `actions`, `x`, `y`, `isMobile`
  - Exports `EntityType`, `EntityMenuAction`, `ViewportSize` types
- **`src/composables/useEntityMenu.test.ts`** — 29 unit tests

## What changed vs app.js

| Before (app.js) | After (useEntityMenu.ts) |
|---|---|
| 3 separate `onEntityClick`, `onInventoryClick`, `onSpellClick` | Single `openMenu(type, name, event)` |
| Inline action builders per handler | `actionsForCharacter/Item/Inventory/Spell` helpers |
| `needsItem` / `needsSpell` handled inside `executeAction` | `selectAction()` with sub-menu flow |
| `window.innerWidth` hard dependency | Optional `viewport` parameter with fallback |

## Test coverage

| Area | Tests |
|------|-------|
| Initial state | 5 |
| Character menu | 5 |
| Item menu | 2 |
| Inventory menu | 3 |
| Spell menu | 2 |
| Close menu | 1 |
| Simple action | 1 |
| Give item sub-menu | 3 |
| Cast spell sub-menu | 3 |
| Mobile mode | 2 |
| Position clamping | 2 |
| **Total** | **29** |

All 157 tests pass (29 entity-menu + 23 music + 44 store + 28 bridge + 28 theme + 5 plugin).

Closes #49
