### PR TITLE
Add Playwright E2E tests and fix python-src URL conflict

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 *.local
+test-results/
+playwright-report/

--- a/web/e2e/game.spec.ts
+++ b/web/e2e/game.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect, type Page } from '@playwright/test'
+
+const APP_URL = '/index-vue.html'
+
+/* ------------------------------------------------------------------ */
+/*  Helper: inject mock game state to bypass Pyodide loading          */
+/* ------------------------------------------------------------------ */
+
+async function injectMockGameState(page: Page) {
+  await page.evaluate(() => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const app = (document.querySelector('#app') as any).__vue_app__
+    const pinia = app.config.globalProperties.$pinia
+    const store = pinia.state.value.game
+
+    store.loading = false
+    store.loadingStatus = ''
+    store.roomName = 'Village Square'
+    store.roomDescription =
+      '<p>The village square is bustling with activity.</p>'
+    store.characters = ['Merchant', 'Guard']
+    store.items = ['Old Key']
+    store.exits = { north: 'Forest Path', south: 'Town Gate' }
+    store.inventory = [
+      { name: 'Wooden Sword', description: 'A simple weapon.' },
+    ]
+    store.spells = [{ name: 'Heal', description: 'Restores health.' }]
+    store.activeQuests = [
+      { name: 'The Missing Amulet', description: 'Find it.' },
+    ]
+    store.completedQuests = []
+    store.lastOutput = '<p>Welcome to <strong>RetroQuest</strong>!</p>'
+    store.acceptingInput = true
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  })
+  // Let Vue re-render
+  await page.waitForTimeout(500)
+}
+
+/* ------------------------------------------------------------------ */
+/*  Loading screen tests (fast — no Pyodide needed)                   */
+/* ------------------------------------------------------------------ */
+
+test.describe('Loading screen', () => {
+  test('shows RetroQuest title and spinner', async ({ page }) => {
+    await page.goto(APP_URL)
+    await expect(page.getByText('RetroQuest', { exact: true })).toBeVisible()
+    await expect(page.locator('.loading-spinner')).toBeVisible()
+  })
+
+  test('shows loading status text', async ({ page }) => {
+    await page.goto(APP_URL)
+    // The loading status should appear (e.g., "Loading Python runtime...")
+    await expect(page.locator('.text-text-secondary')).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+
+  test('does not show game UI while loading', async ({ page }) => {
+    await page.goto(APP_URL)
+    await expect(page.locator('input[type="text"]')).toBeHidden()
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  Game UI tests (mock game state injected, no Pyodide needed)       */
+/* ------------------------------------------------------------------ */
+
+test.describe('Game UI with mock state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(APP_URL)
+    // Wait for Vue to mount (loading screen appears)
+    await expect(page.locator('.loading-spinner')).toBeVisible({
+      timeout: 10_000,
+    })
+    // Inject mock state to skip past loading
+    await injectMockGameState(page)
+  })
+
+  test('game layout is visible after loading completes', async ({ page }) => {
+    await expect(page.locator('text=⚔️ RetroQuest').first()).toBeVisible()
+    await expect(page.locator('input[type="text"]')).toBeVisible()
+  })
+
+  test('sidebar shows quest, inventory, and spells sections', async ({
+    page,
+  }) => {
+    await expect(page.getByText('Active Quests').first()).toBeVisible()
+    await expect(page.getByText('Inventory').first()).toBeVisible()
+    await expect(page.getByText('Spells').first()).toBeVisible()
+  })
+
+  test('sidebar displays injected data', async ({ page }) => {
+    await expect(page.getByText('The Missing Amulet').first()).toBeVisible()
+    await expect(page.getByText('Wooden Sword').first()).toBeVisible()
+    await expect(page.getByText('Heal').first()).toBeVisible()
+  })
+
+  test('section headers toggle collapse', async ({ page }) => {
+    const header = page.getByText('Active Quests').first()
+    await header.click()
+    // After collapse, quest item should be hidden
+    await expect(page.getByText('The Missing Amulet')).toBeHidden()
+    // Click again to expand
+    await header.click()
+    await expect(page.getByText('The Missing Amulet').first()).toBeVisible()
+  })
+
+  test('save and load buttons are visible', async ({ page }) => {
+    await expect(page.getByRole('button', { name: '💾 Save' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '📂 Load' })).toBeVisible()
+  })
+
+  test('mute toggle button is visible', async ({ page }) => {
+    await expect(
+      page.getByRole('button', { name: /mute music/i }),
+    ).toBeVisible()
+  })
+
+  test('room name is displayed', async ({ page }) => {
+    await expect(page.getByText('Village Square').first()).toBeVisible()
+  })
+
+  test('exit chips are rendered', async ({ page }) => {
+    await expect(page.locator('button.border-exits').first()).toBeVisible()
+    await expect(page.getByText('Forest Path').first()).toBeVisible()
+  })
+
+  test('character chips are rendered', async ({ page }) => {
+    await expect(page.locator('button.border-character').first()).toBeVisible()
+  })
+
+  test('game output shows history', async ({ page }) => {
+    await expect(page.getByText('Welcome to RetroQuest!').first()).toBeVisible()
+  })
+
+  test('command input has correct placeholder', async ({ page }) => {
+    const input = page.locator('input[type="text"]')
+    const placeholder = await input.getAttribute('placeholder')
+    expect(placeholder).toBeTruthy()
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/*  Mobile layout tests                                               */
+/* ------------------------------------------------------------------ */
+
+test.describe('Mobile viewport', () => {
+  test.use({ viewport: { width: 375, height: 812 } })
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(APP_URL)
+    await expect(page.locator('.loading-spinner')).toBeVisible({
+      timeout: 10_000,
+    })
+    await injectMockGameState(page)
+  })
+
+  test('sidebar is hidden on mobile', async ({ page }) => {
+    const sidebar = page.locator('.max-md\\:hidden')
+    await expect(sidebar).toBeHidden()
+  })
+
+  test('hamburger opens and close button closes drawer', async ({ page }) => {
+    const hamburger = page.getByRole('button', {
+      name: 'Open sidebar',
+    })
+    await expect(hamburger).toBeVisible()
+
+    await hamburger.click()
+    await expect(page.getByText('Menu').first()).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Close menu' })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Close menu' }).click()
+    await expect(page.getByRole('button', { name: 'Close menu' })).toBeHidden()
+  })
+})

--- a/web/index-vue.html
+++ b/web/index-vue.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>RetroQuest — The Awakening</title>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.27.7/full/pyodide.js"></script>
 </head>
 <body>
     <div id="app"></div>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/vite": "^4.2.2",
         "@types/node": "^25.6.0",
         "@vitejs/plugin-vue": "^6.0.6",
@@ -603,6 +604,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3201,6 +3218,53 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,10 +11,12 @@
     "typecheck": "vue-tsc --noEmit",
     "lint": "eslint . --ext .ts,.vue",
     "format": "prettier --write \"src/**/*.{ts,vue}\" \"vite-plugins/**/*.ts\" \"*.config.*\"",
-    "format:check": "prettier --check \"src/**/*.{ts,vue}\" \"vite-plugins/**/*.ts\" \"*.config.*\""
+    "format:check": "prettier --check \"src/**/*.{ts,vue}\" \"vite-plugins/**/*.ts\" \"*.config.*\"",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.2",
     "@types/node": "^25.6.0",
     "@vitejs/plugin-vue": "^6.0.6",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: 'list',
+  timeout: 30_000,
+  expect: {
+    timeout: 15_000,
+  },
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev -- --host 0.0.0.0',
+    url: 'http://localhost:5173/index-vue.html',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+})

--- a/web/src/composables/useBridge.ts
+++ b/web/src/composables/useBridge.ts
@@ -73,7 +73,7 @@ controller = GameController(game)
     onProgress: (status: string) => void,
   ): Promise<void> {
     if (!pyodide) throw new Error('Pyodide not initialized')
-    const resp = await fetch('/src/manifest.json')
+    const resp = await fetch('/python-src/manifest.json')
     const manifest: string[] = await resp.json()
     const total = manifest.length
     let loaded = 0
@@ -84,7 +84,7 @@ controller = GameController(game)
         `import os\nos.makedirs('/home/pyodide/src/${dir}', exist_ok=True)`,
       )
 
-      const fileResp = await fetch(`/src/${filePath}`)
+      const fileResp = await fetch(`/python-src/${filePath}`)
       const content = await fileResp.text()
 
       pyodide.runPython(

--- a/web/src/composables/useMusic.test.ts
+++ b/web/src/composables/useMusic.test.ts
@@ -76,7 +76,7 @@ describe('useMusic', () => {
     it('sets audio src and plays when not muted', () => {
       const { loadTrack } = useMusic(audio)
       loadTrack('tavern.mp3', 'Tavern theme')
-      expect(audio.src).toBe('/src/retroquest/audio/music/tavern.mp3')
+      expect(audio.src).toBe('/python-src/retroquest/audio/music/tavern.mp3')
       expect(audio.play).toHaveBeenCalled()
     })
 
@@ -91,7 +91,7 @@ describe('useMusic', () => {
       localStorage.setItem('retroquest_music_muted', 'true')
       const { loadTrack } = useMusic(audio)
       loadTrack('tavern.mp3', 'Tavern theme')
-      expect(audio.src).toBe('/src/retroquest/audio/music/tavern.mp3')
+      expect(audio.src).toBe('/python-src/retroquest/audio/music/tavern.mp3')
       expect(audio.play).not.toHaveBeenCalled()
     })
 
@@ -117,7 +117,7 @@ describe('useMusic', () => {
       const { loadTrack } = useMusic(audio)
       loadTrack('my track (remix).mp3', 'Info')
       expect(audio.src).toBe(
-        '/src/retroquest/audio/music/my%20track%20(remix).mp3',
+        '/python-src/retroquest/audio/music/my%20track%20(remix).mp3',
       )
     })
 

--- a/web/src/composables/useMusic.ts
+++ b/web/src/composables/useMusic.ts
@@ -2,7 +2,7 @@ import { ref } from 'vue'
 import { escapeHtml } from '@/utils/theme'
 
 const STORAGE_KEY = 'retroquest_music_muted'
-const MUSIC_BASE_PATH = '/src/retroquest/audio/music/'
+const MUSIC_BASE_PATH = '/python-src/retroquest/audio/music/'
 const URL_PATTERN = /(https?:\/\/[^\s]+)/g
 
 export function useMusic(audio: HTMLAudioElement) {

--- a/web/vite-plugins/pythonSourcePlugin.ts
+++ b/web/vite-plugins/pythonSourcePlugin.ts
@@ -1,6 +1,6 @@
 /**
  * Vite plugin that serves Python source files from the project's
- * src/ directory at the /src/ URL path, replacing serve.py.
+ * src/ directory at the /python-src/ URL path, replacing serve.py.
  */
 import { type Plugin } from 'vite'
 import type { ServerResponse } from 'node:http'
@@ -44,13 +44,18 @@ function serveManifest(srcDir: string, res: ServerResponse): void {
   res.end(body)
 }
 
+/** URL prefix used to serve Python source files. */
+const PYTHON_SRC_PREFIX = '/python-src/'
+
 /** Respond with a single file from the source directory. */
 function serveSourceFile(
   srcDir: string,
   urlPath: string,
   res: ServerResponse,
 ): void {
-  const relativePath = decodeURIComponent(urlPath.slice('/src/'.length))
+  const relativePath = decodeURIComponent(
+    urlPath.slice(PYTHON_SRC_PREFIX.length),
+  )
   const filePath = resolve(srcDir, relativePath)
 
   if (!filePath.startsWith(resolve(srcDir))) {
@@ -74,8 +79,9 @@ function serveSourceFile(
 }
 
 /**
- * Vite plugin that mounts the Python source tree at /src/ and
- * provides a /src/manifest.json endpoint listing all .py files.
+ * Vite plugin that mounts the Python source tree at /python-src/
+ * and provides a /python-src/manifest.json endpoint listing all
+ * .py files.
  */
 export function pythonSourcePlugin(options: PythonSourcePluginOptions): Plugin {
   const { srcDir } = options
@@ -86,12 +92,12 @@ export function pythonSourcePlugin(options: PythonSourcePluginOptions): Plugin {
       server.middlewares.use((req, res, next) => {
         const urlPath = stripQueryAndFragment(req.url ?? '')
 
-        if (urlPath === '/src/manifest.json') {
+        if (urlPath === '/python-src/manifest.json') {
           serveManifest(srcDir, res)
           return
         }
 
-        if (urlPath.startsWith('/src/')) {
+        if (urlPath.startsWith(PYTHON_SRC_PREFIX)) {
           serveSourceFile(srcDir, urlPath, res)
           return
         }


### PR DESCRIPTION
Closes #52

## Summary

Adds Playwright E2E test infrastructure and a suite of 16 browser tests covering the Vue frontend. Also fixes a critical URL conflict where the `pythonSourcePlugin` middleware intercepted all `/src/*` requests meant for Vite's dev server.

## Changes

### Playwright E2E tests (`web/e2e/game.spec.ts`)
- **Loading screen** (3 tests): title, spinner, loading status, game UI hidden while loading
- **Game UI with mock state** (11 tests): layout, sidebar sections, sidebar data, section collapse, save/load buttons, mute toggle, room name, exit chips, character chips, game output, command input
- **Mobile viewport** (2 tests, 375x812): sidebar hidden, hamburger opens/closes drawer
- Uses Pinia store injection to mock game state, bypassing Pyodide loading entirely

### pythonSourcePlugin URL prefix fix
- Changed URL mount point from `/src/` to `/python-src/` to avoid conflicts with Vite serving Vue/TS source files from `web/src/`
- Updated `useBridge.ts` and `useMusic.ts` fetch paths accordingly

### Other fixes
- Added missing Pyodide CDN `<script>` tag to `index-vue.html`
- Added `test-results/` and `playwright-report/` to `.gitignore`

## Testing

- All 16 E2E tests pass (15.6s)
- All 157 unit tests pass
- TypeScript and ESLint checks pass

Formatting constraints verified.
