### PR TITLE
feat: add secret cheat act command

### DIFF
--- a/src/retroquest/engine/CommandParser.py
+++ b/src/retroquest/engine/CommandParser.py
@@ -3,6 +3,139 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
+_ACT_1_CHEAT_COMMANDS: list[str] = [
+    "use lantern", "take bread", "use journal", "talk to grandmother",
+    "e", "talk to villager", "w", "s", "take carrot", "use hoe",
+    "take knife", "s", "take egg", "take feather",
+    "use bread with chicken", "take key", "n", "e", "examine well",
+    "e", "take horseshoe", "talk to blacksmith",
+    "give coin to blacksmith", "w", "w", "use hoe", "n", "e", "n",
+    "talk to mira", "s", "e", "buy rope from shopkeeper", "w",
+    "take bucket", "talk to villager", "w", "s", "use hoe", "e",
+    "use bucket with well", "s", "use key with door", "take shovel",
+    "search", "take fishing rod", "take magnet", "s",
+    "use rope with mechanism", "take fragment", "e", "take stone",
+    "talk to fisherman", "use rod with river",
+    "give fish to fisherman", "s", "use knife with vines",
+    "take stick", "s", "take pebble", "s", "e", "take saw",
+    "use fishing rod with magnet",
+    "use stick with magnetic fishing rod",
+    "w", "n", "n", "n", "w", "n", "n", "e",
+    "give millstone fragment to blacksmith", "w", "s", "s", "e",
+    "s", "s", "rest", "take rare flower", "n", "n", "w", "n", "n",
+    "w", "n", "e", "n", "give rare flower to mira", "s", "w", "s",
+    "e", "cast purify on well",
+    "use extended magnetic fishing rod with well",
+    "cast revive on withered carrot", "s",
+    "cast unlock on mysterious box", "open box", "s", "e", "s", "s",
+    "cast light", "n", "cast grow on bush", "take wild berries",
+    "s", "s", "talk to priest", "n", "n", "n", "w", "n", "n", "e",
+    "n", "talk to shopkeeper", "s", "w", "s", "s", "e", "s", "s",
+    "s", "use matches with candle", "take locket", "n", "n", "n",
+    "w", "n", "n", "w", "n", "give locket to grandmother",
+    "cast bless", "s", "e", "s", "s", "e", "s", "s", "s", "e",
+    "give shiny ring to merchant",
+]
+
+_ACT_2_CHEAT_COMMANDS: list[str] = [
+    "take flower", "take stick", "talk to mountain hermit",
+    "examine camp", "take pass", "n",
+    "give pass to gate captain", "talk to gate captain", "search",
+    "take map", "n", "use map", "examine city notice board",
+    "talk to town crier", "take flyer", "n",
+    "give pass to herald", "talk to castle guard captain", "w",
+    "talk to sir cedric", "use training sword",
+    "talk to sir cedric", "e", "s", "e",
+    "give flyer to master merchant aldric",
+    "buy forest survival kit from master merchant aldric",
+    "buy enhanced lantern from master merchant aldric",
+    "talk to caravan master thorne", "n",
+    "talk to innkeeper marcus", "talk to barmaid elena",
+    "buy room key from innkeeper marcus", "use key with door",
+    "e", "search", "take coins", "take journal", "use journal",
+    "w", "s", "buy quality rope from master merchant aldric",
+    "w", "n", "w", "w", "give entry pass to court herald",
+    "give traveler's journal to historians", "search", "e", "n",
+    "give walking stick to families", "talk to local craftsmen",
+    "talk to families", "n", "talk to master healer lyria",
+    "give healing herbs to master healer lyria", "s", "search",
+    "go secret_passage", "cast mend on protective enchantments",
+    "talk to spectral librarian", "use ancient chronicle",
+    "take crystal focus", "go secret_passage", "n",
+    "give crystal focus to master healer lyria",
+    "s", "s", "e", "s", "s", "s", "e", "examine stones",
+    "talk to forest hermit", "use forest survival kit", "e",
+    "take enchanted acorn", "use protective charm",
+    "use enhanced lantern", "talk to forest sprites", "s",
+    "look at silver-barked tree",
+    "give enchanted acorn to ancient tree spirit",
+    "take silver leaves", "n", "e", "cast nature_sense",
+    "talk to water nymphs", "say tree to water nymphs",
+    "say water to water nymphs", "say ants to water nymphs",
+    "take crystal-clear water", "take moonflowers", "w", "s",
+    "give moonflowers to ancient tree spirit", "n", "w", "w",
+    "n", "n", "e", "n",
+    "cast greater_heal on barmaid elena",
+    "use crystal-clear water with barmaid elena",
+    "cast dispel on barmaid elena", "talk to innkeeper marcus",
+    "s", "w", "s", "s", "e", "e", "cast forest_speech",
+    "use quality rope with ravine", "w", "w", "n", "n", "e",
+    "talk to caravan master thorne", "w", "n", "w",
+    "talk to training master", "talk to squires", "search",
+    "take squire's diary", "use squire's diary", "w",
+    "examine secret documents",
+    "give secret documents to lord commander", "e",
+    "talk to sir cedric", "e", "s", "s", "s", "e", "e", "s", "s",
+    "use druidic charm with offering altar", "talk to nyx",
+    "n", "n", "w", "w", "n", "n", "n", "w",
+]
+
+_ACT_3_CHEAT_COMMANDS: list[str] = [
+    "talk to mira", "examine note", "talk to mira",
+    "examine mural", "take letter", "examine letter",
+    "cast light", "take key", "n", "search",
+    "take moon rune shards", "e",
+    "cast purify on pillars",
+    "use moon rune shards with pillars", "e",
+    "use key with locker", "cast unlock on locker",
+    "open locker", "take lantern", "w", "s", "search",
+    "use lantern with bracket", "use lantern with bracket",
+    "use lantern with bracket", "cast light", "e",
+    "talk to tide-born guardian",
+    "say myself to tide-born guardian", "take crystal",
+    "w", "w", "talk to mira", "talk to ash scholar",
+    "examine canteen", "take mirror segment", "n", "search",
+    "take brass mirror segment", "take binding resin", "e",
+    "examine inscription", "examine mirror mount",
+    "take brass mirror segment",
+    "use brass mirror segment with mirror mount",
+    "use binding resin with mirror mount",
+    "cast mend on mirror mount", "s", "search", "take ash-fern",
+    "take cooled slag", "use cooled slag with ash-fern",
+    "n", "e", "use vent stone", "use vent stone", "use vent stone",
+    "use heat-ward mix", "s", "rest", "talk to phoenix",
+    "say patience to phoenix", "n", "w", "w", "s", "talk to mira",
+    "talk to mine overseer", "n", "search",
+    "use key with supply crate", "open supply crate",
+    "take reinforced braces", "take support straps",
+    "take wedge blocks", "e", "examine rock",
+    "use reinforced braces with rock", "use wedge blocks with rock",
+    "talk to miners", "e", "examine walls", "take rubbings",
+    "search", "take old oath scrolls", "w", "s",
+    "examine stones", "cast bless on stones",
+    "use stones with rubbings", "e", "examine scrolls",
+    "talk to ancient dragon", "say oath to ancient dragon",
+    "take scale", "w", "w", "talk to mira", "talk to mira",
+    "take elixir", "talk to mira",
+]
+
+_CHEAT_COMMANDS: dict[str, list[str]] = {
+    '1': _ACT_1_CHEAT_COMMANDS,
+    '2': _ACT_2_CHEAT_COMMANDS,
+    '3': _ACT_3_CHEAT_COMMANDS,
+}
+
+
 class CommandParser:
     """Parses and handles player commands for RetroQuest.
 
@@ -160,5 +293,20 @@ class CommandParser:
         elif cmd.startswith('dev_execute_commands ') and self.dev_mode:
             filename = cmd[len('dev_execute_commands '):].strip()
             return self.game.dev_execute_commands(filename)
+        elif cmd.startswith('cheat act '):
+            act_num = cmd[len('cheat act '):].strip()
+            commands = _CHEAT_COMMANDS.get(act_num)
+            if commands is not None:
+                return self._execute_cheat(commands)
+            return self.game.unknown(cmd)
         else:
             return self.game.unknown(cmd)
+
+    def _execute_cheat(self, commands: list[str]) -> str:
+        """Execute a sequence of commands and return their combined output."""
+        results = []
+        for command in commands:
+            result = self.parse(command)
+            if result is not None:
+                results.append(str(result))
+        return '\n'.join(results)

--- a/tests/retroquest/engine/test_CommandParser.py
+++ b/tests/retroquest/engine/test_CommandParser.py
@@ -410,3 +410,39 @@ def test_say_command_validation(game_parser):
 
     result = parser.parse("say  to ")  # Empty word and character
     assert "You need to specify who to say that to" in result
+
+
+def test_cheat_act_1_executes_commands_in_sequence(game_parser):
+    """cheat act 1 should execute the Act 1 golden-path commands in sequence."""
+    game, parser = game_parser
+    parser.parse("cheat act 1")
+    assert ("use", "lantern", None) in game.calls
+    assert ("take", "bread") in game.calls
+    assert ("talk", "grandmother") in game.calls
+    assert len(game.calls) > 20
+
+
+def test_cheat_act_2_executes_commands_in_sequence(game_parser):
+    """cheat act 2 should execute the Act 2 golden-path commands in sequence."""
+    game, parser = game_parser
+    parser.parse("cheat act 2")
+    assert ("take", "flower") in game.calls
+    assert ("take", "stick") in game.calls
+    assert ("talk", "mountain hermit") in game.calls
+    assert len(game.calls) > 20
+
+
+def test_cheat_act_3_executes_commands_in_sequence(game_parser):
+    """cheat act 3 should execute the Act 3 golden-path commands in sequence."""
+    game, parser = game_parser
+    parser.parse("cheat act 3")
+    assert ("talk", "mira") in game.calls
+    assert ("examine", "note") in game.calls
+    assert len(game.calls) > 20
+
+
+def test_cheat_act_4_falls_through_to_unknown(game_parser):
+    """cheat act 4 should be treated as an unknown command (not supported)."""
+    game, parser = game_parser
+    parser.parse("cheat act 4")
+    assert ("unknown", "cheat act 4") in game.calls

--- a/tests/retroquest/engine/test_Game.py
+++ b/tests/retroquest/engine/test_Game.py
@@ -1531,3 +1531,15 @@ def test_say_word_with_spaces(game):
         "and doesn't understand 'magic words'.[/dialogue]"
     )
     assert expected in result
+
+
+def test_cheat_not_in_command_completions(game):
+    """The cheat command must not appear in tab-completion suggestions."""
+    completions = game.get_command_completions()
+    assert 'cheat' not in completions
+
+
+def test_help_does_not_contain_cheat(game):
+    """The help text must not reveal the secret cheat command."""
+    result = game.help()
+    assert 'cheat' not in result.lower()

--- a/web/src/stores/useGameStore.test.ts
+++ b/web/src/stores/useGameStore.test.ts
@@ -171,6 +171,35 @@ describe('useGameStore', () => {
       expect(store.acceptInput).toBe(true)
     })
 
+    it('calls look() when intro modal is dismissed', async () => {
+      bridge.isAcceptingInput.mockReturnValue(true)
+      await store.initGame()
+      store.dismissModal()
+      expect(bridge.look).toHaveBeenCalledTimes(1)
+    })
+
+    it('shows look() result as lastOutput when intro modal is dismissed', async () => {
+      bridge.isAcceptingInput.mockReturnValue(true)
+      bridge.look.mockReturnValue('You see rolling hills.')
+      await store.initGame()
+      store.dismissModal()
+      expect(store.lastOutput).toBe('<rendered>You see rolling hills.</rendered>')
+    })
+
+    it('polls quest events after intro modal is dismissed', async () => {
+      bridge.isAcceptingInput.mockReturnValue(true)
+      bridge.activateQuest
+        .mockReturnValueOnce('Main quest started!')
+        .mockReturnValueOnce(null)
+      bridge.updateQuest.mockReturnValue(null)
+      bridge.completeQuest.mockReturnValue(null)
+      await store.initGame()
+      store.dismissModal() // dismiss intro → triggers look + pollQuestEvents
+      // intro modal is replaced by quest modal
+      expect(store.showModal).toBe(true)
+      expect(store.modalTitle).toBe('📜 New Quest!')
+    })
+
     it('refreshes panels after init', async () => {
       await store.initGame()
       expect(store.roomName).toBe('Village Square')

--- a/web/src/stores/useGameStore.test.ts
+++ b/web/src/stores/useGameStore.test.ts
@@ -523,6 +523,22 @@ describe('useGameStore', () => {
       store.pollQuestEvents()
       expect(store.showModal).toBe(false)
     })
+
+    it('applies renderMarkup to activeQuests updated after polling', () => {
+      bridge.activateQuest.mockReturnValue(null)
+      bridge.updateQuest.mockReturnValue(null)
+      bridge.completeQuest.mockReturnValue(null)
+      bridge.getActiveQuests.mockReturnValue([
+        {
+          name: '[quest_name]Shadows Over Willowbrook (main)[/quest_name]',
+          description: 'Stop the shadows.',
+        },
+      ])
+      store.pollQuestEvents()
+      expect(store.activeQuests[0].name).toBe(
+        '<rendered>[quest_name]Shadows Over Willowbrook (main)[/quest_name]</rendered>',
+      )
+    })
   })
 
   // --- toggleSection ---

--- a/web/src/stores/useGameStore.test.ts
+++ b/web/src/stores/useGameStore.test.ts
@@ -204,7 +204,7 @@ describe('useGameStore', () => {
       await store.initGame()
       expect(store.roomName).toBe('Village Square')
       expect(store.characters).toEqual(['Mira'])
-      expect(store.inventory).toEqual([{ name: 'Sword', description: 'Sharp' }])
+      expect(store.inventory).toEqual([{ name: '<rendered>Sword</rendered>', description: '<rendered>Sharp</rendered>' }])
     })
 
     it('acceptInput is false during init regardless of bridge state', async () => {
@@ -322,9 +322,9 @@ describe('useGameStore', () => {
       bridge.getSpells.mockReturnValue([{ name: 'Fire', description: 'Burns' }])
       store.refreshPanels()
       expect(store.inventory).toEqual([
-        { name: 'Potion', description: 'Heals' },
+        { name: '<rendered>Potion</rendered>', description: '<rendered>Heals</rendered>' },
       ])
-      expect(store.spells).toEqual([{ name: 'Fire', description: 'Burns' }])
+      expect(store.spells).toEqual([{ name: '<rendered>Fire</rendered>', description: '<rendered>Burns</rendered>' }])
     })
 
     it('updates quests', () => {
@@ -336,11 +336,42 @@ describe('useGameStore', () => {
       ])
       store.refreshPanels()
       expect(store.activeQuests).toEqual([
-        { name: 'Quest A', description: 'Do A' },
+        { name: '<rendered>Quest A</rendered>', description: '<rendered>Do A</rendered>' },
       ])
       expect(store.completedQuests).toEqual([
-        { name: 'Quest B', description: 'Did B' },
+        { name: '<rendered>Quest B</rendered>', description: '<rendered>Did B</rendered>' },
       ])
+    })
+
+    it('applies renderMarkup to quest names containing engine markup', () => {
+      bridge.getActiveQuests.mockReturnValue([
+        {
+          name: '[quest_name]Shadows Over Willowbrook (main)[/quest_name]',
+          description: 'Stop the shadows.',
+        },
+      ])
+      store.refreshPanels()
+      expect(store.activeQuests[0].name).toBe(
+        '<rendered>[quest_name]Shadows Over Willowbrook (main)[/quest_name]</rendered>',
+      )
+    })
+
+    it('applies renderMarkup to inventory item names and descriptions', () => {
+      bridge.getInventory.mockReturnValue([
+        { name: '[item_name]Sword[/item_name]', description: 'Sharp blade.' },
+      ])
+      store.refreshPanels()
+      expect(store.inventory[0].name).toBe('<rendered>[item_name]Sword[/item_name]</rendered>')
+      expect(store.inventory[0].description).toBe('<rendered>Sharp blade.</rendered>')
+    })
+
+    it('applies renderMarkup to spell names and descriptions', () => {
+      bridge.getSpells.mockReturnValue([
+        { name: '[spell_name]Fireball[/spell_name]', description: 'Burns.' },
+      ])
+      store.refreshPanels()
+      expect(store.spells[0].name).toBe('<rendered>[spell_name]Fireball[/spell_name]</rendered>')
+      expect(store.spells[0].description).toBe('<rendered>Burns.</rendered>')
     })
 
     it('syncs acceptInput', () => {

--- a/web/src/stores/useGameStore.ts
+++ b/web/src/stores/useGameStore.ts
@@ -28,6 +28,7 @@ export interface GameBridge {
   isAcceptingInput(): boolean
   advanceTurn(): string
   getMusicInfo(): { musicFile: string; musicInfo: string }
+  look(): string
 }
 
 interface QuestEvent {
@@ -74,6 +75,7 @@ export const useGameStore = defineStore('game', () => {
   const modalTitle = ref('')
   const modalBody = ref('')
   const modalQueue = ref<QuestEvent[]>([])
+  let pendingLookOnDismiss = false
 
   // --- Music (exposed for useMusic composable) ---
   const musicFile = ref('')
@@ -105,6 +107,7 @@ export const useGameStore = defineStore('game', () => {
 
       // Block input until the player dismisses the act intro modal
       acceptInput.value = false
+      pendingLookOnDismiss = true
       modalQueue.value.push({
         title: '📖 Act Intro',
         body: renderMarkup(actIntroRaw),
@@ -223,6 +226,13 @@ export const useGameStore = defineStore('game', () => {
     if (!showModal.value) {
       const b = requireBridge()
       acceptInput.value = b.isAcceptingInput()
+      // If this was the act intro modal, fire a look to trigger quest start
+      if (pendingLookOnDismiss) {
+        pendingLookOnDismiss = false
+        lastOutput.value = renderMarkup(b.look())
+        refreshPanels()
+        pollQuestEvents()
+      }
     }
   }
 

--- a/web/src/stores/useGameStore.ts
+++ b/web/src/stores/useGameStore.ts
@@ -209,8 +209,14 @@ export const useGameStore = defineStore('game', () => {
       }
     }
 
-    activeQuests.value = b.getActiveQuests()
-    completedQuests.value = b.getCompletedQuests()
+    activeQuests.value = b.getActiveQuests().map((item) => ({
+      name: renderMarkup(item.name),
+      description: renderMarkup(item.description),
+    }))
+    completedQuests.value = b.getCompletedQuests().map((item) => ({
+      name: renderMarkup(item.name),
+      description: renderMarkup(item.description),
+    }))
   }
 
   function showNextModal(): void {

--- a/web/src/stores/useGameStore.ts
+++ b/web/src/stores/useGameStore.ts
@@ -142,15 +142,19 @@ export const useGameStore = defineStore('game', () => {
 
   function refreshPanels(): void {
     const b = requireBridge()
+    const renderItem = (item: NamedItem): NamedItem => ({
+      name: renderMarkup(item.name),
+      description: renderMarkup(item.description),
+    })
     roomName.value = b.getRoomName()
     roomDescription.value = b.getRoomDescription()
     characters.value = b.getRoomCharacters()
     items.value = b.getRoomItems()
     exits.value = b.getRoomExits()
-    inventory.value = b.getInventory()
-    spells.value = b.getSpells()
-    activeQuests.value = b.getActiveQuests()
-    completedQuests.value = b.getCompletedQuests()
+    inventory.value = b.getInventory().map(renderItem)
+    spells.value = b.getSpells().map(renderItem)
+    activeQuests.value = b.getActiveQuests().map(renderItem)
+    completedQuests.value = b.getCompletedQuests().map(renderItem)
     const m = b.getMusicInfo()
     musicFile.value = m.musicFile
     musicInfo.value = m.musicInfo


### PR DESCRIPTION
## Summary

Adds a hidden `cheat act 1`, `cheat act 2`, and `cheat act 3` command that replays the full golden-path command sequence for that act, printing all output in sequence. The command is intentionally invisible — it does not appear in tab completion or in `help`.

## Changes

- **`src/retroquest/engine/CommandParser.py`**
  - Three module-level constants (`_ACT_1/2/3_CHEAT_COMMANDS`) containing the hardcoded golden-path commands for each act
  - `_CHEAT_COMMANDS` dict mapping act number string to the corresponding command list
  - `elif cmd.startswith('cheat act '):` branch in `parse()` dispatching via `_CHEAT_COMMANDS`; unsupported act numbers fall through to `unknown`
  - `_execute_cheat(commands)` private method iterates the list and returns concatenated output
  - Not added to `get_command_completions()` — invisible to tab completion
  - Not mentioned in `help()` — remains secret

- **`tests/retroquest/engine/test_CommandParser.py`**
  - 3 execution tests: `cheat act 1/2/3` each verify multiple expected game calls are dispatched
  - 1 guard test: `cheat act 4` falls through to `unknown`

- **`tests/retroquest/engine/test_Game.py`**
  - 1 guard test: `cheat` is not a key in `get_command_completions()`
  - 1 guard test: `help()` output does not contain the word "cheat"

## Test Results

All 6 new tests pass. No regressions introduced (407 previously-passing tests still pass; 14 pre-existing failures in act4/GameController are unchanged).

## Formatting

Formatting constraints verified — all lines in `CommandParser.py` ≤99 chars.