### PR TITLE
feat: move action buttons to mobile drawer to fix toolbar overflow

### DIFF
--- a/web/e2e/game.spec.ts
+++ b/web/e2e/game.spec.ts
@@ -375,3 +375,59 @@ test.describe('Mobile viewport', () => {
     await expect(page.getByRole('button', { name: 'Close menu' })).toBeHidden()
   })
 })
+
+/* ------------------------------------------------------------------ */
+/*  Mobile toolbar overflow fix                                        */
+/* ------------------------------------------------------------------ */
+
+test.describe('Mobile toolbar overflow fix', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(APP_URL)
+    await expect(page.locator('.loading-spinner')).toBeVisible({
+      timeout: 10_000,
+    })
+    await injectMockGameState(page)
+  })
+
+  test('Quicksave, Quickload, Save, Load, Help are hidden in toolbar on mobile', async ({
+    page,
+  }) => {
+    await expect(
+      page.getByRole('button', { name: /Quicksave/i }).first(),
+    ).toBeHidden()
+    await expect(
+      page.getByRole('button', { name: /Quickload/i }).first(),
+    ).toBeHidden()
+    await expect(
+      page.getByRole('button', { name: /^💾 Save$/i }),
+    ).toBeHidden()
+    await expect(
+      page.getByRole('button', { name: /^📂 Load$/i }),
+    ).toBeHidden()
+    await expect(
+      page.getByRole('button', { name: /^❓ Help$/i }),
+    ).toBeHidden()
+  })
+
+  test('drawer shows Quicksave, Quickload, Save, Load, Help action chips', async ({
+    page,
+  }) => {
+    await page.getByRole('button', { name: 'Open sidebar' }).click()
+    const drawer = page.getByTestId('mobile-drawer-panel')
+    await expect(drawer.getByRole('button', { name: /Quicksave/i })).toBeVisible()
+    await expect(drawer.getByRole('button', { name: /Quickload/i })).toBeVisible()
+    await expect(drawer.getByRole('button', { name: /Save/i }).first()).toBeVisible()
+    await expect(drawer.getByRole('button', { name: /Load/i }).first()).toBeVisible()
+    await expect(drawer.getByRole('button', { name: /Help/i }).first()).toBeVisible()
+  })
+
+  test('tapping a drawer action chip closes the drawer', async ({ page }) => {
+    await page.getByRole('button', { name: 'Open sidebar' }).click()
+    const drawer = page.getByTestId('mobile-drawer-panel')
+    await expect(drawer).toBeVisible()
+    await drawer.getByRole('button', { name: /Quicksave/i }).click()
+    await expect(drawer).toBeHidden()
+  })
+})

--- a/web/src/components/GameLayout.vue
+++ b/web/src/components/GameLayout.vue
@@ -256,6 +256,11 @@ function closeMenus() {
       @close="showDrawer = false"
       @inventory-click="onInventoryClick"
       @spell-click="onSpellClick"
+      @quick-save="store.saveGame()"
+      @quick-load="store.loadGame()"
+      @save="onOpenSaveDialog"
+      @load="onOpenLoadDialog"
+      @help="onHelp"
     />
 
     <QuestModal

--- a/web/src/components/MobileDrawer.vue
+++ b/web/src/components/MobileDrawer.vue
@@ -24,6 +24,11 @@ defineEmits<{
   close: []
   inventoryClick: [event: MouseEvent, name: string]
   spellClick: [event: MouseEvent, name: string]
+  quickSave: []
+  quickLoad: []
+  save: []
+  load: []
+  help: []
 }>()
 </script>
 
@@ -47,6 +52,55 @@ defineEmits<{
           @click="$emit('close')"
         >
           ✕
+        </button>
+      </div>
+
+      <!-- Action chips -->
+      <div class="flex flex-wrap gap-2 pb-3 border-b border-border mb-3">
+        <button
+          class="bg-chip-bg text-text-primary border border-border rounded-md px-3 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
+          @click="
+            $emit('quickSave')
+            $emit('close')
+          "
+        >
+          ⚡ Quicksave
+        </button>
+        <button
+          class="bg-chip-bg text-text-primary border border-border rounded-md px-3 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
+          @click="
+            $emit('quickLoad')
+            $emit('close')
+          "
+        >
+          ⚡ Quickload
+        </button>
+        <button
+          class="bg-chip-bg text-text-primary border border-border rounded-md px-3 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
+          @click="
+            $emit('save')
+            $emit('close')
+          "
+        >
+          💾 Save
+        </button>
+        <button
+          class="bg-chip-bg text-text-primary border border-border rounded-md px-3 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
+          @click="
+            $emit('load')
+            $emit('close')
+          "
+        >
+          📂 Load
+        </button>
+        <button
+          class="bg-chip-bg text-text-primary border border-border rounded-md px-3 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
+          @click="
+            $emit('help')
+            $emit('close')
+          "
+        >
+          ❓ Help
         </button>
       </div>
 

--- a/web/src/components/MobileDrawer.vue
+++ b/web/src/components/MobileDrawer.vue
@@ -20,7 +20,7 @@ defineProps<{
   spells: NamedItem[]
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   close: []
   inventoryClick: [event: MouseEvent, name: string]
   spellClick: [event: MouseEvent, name: string]
@@ -30,6 +30,17 @@ defineEmits<{
   load: []
   help: []
 }>()
+
+function emitAndClose(
+  action: 'quickSave' | 'quickLoad' | 'save' | 'load' | 'help',
+) {
+  if (action === 'quickSave') emit('quickSave')
+  else if (action === 'quickLoad') emit('quickLoad')
+  else if (action === 'save') emit('save')
+  else if (action === 'load') emit('load')
+  else emit('help')
+  emit('close')
+}
 </script>
 
 <template>
@@ -59,46 +70,31 @@ defineEmits<{
       <div class="flex flex-wrap gap-2 pb-3 border-b border-border mb-3">
         <button
           class="bg-chip-bg text-text-primary border border-border rounded-md px-3 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
-          @click="
-            $emit('quickSave')
-            $emit('close')
-          "
+          @click="emitAndClose('quickSave')"
         >
           ⚡ Quicksave
         </button>
         <button
           class="bg-chip-bg text-text-primary border border-border rounded-md px-3 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
-          @click="
-            $emit('quickLoad')
-            $emit('close')
-          "
+          @click="emitAndClose('quickLoad')"
         >
           ⚡ Quickload
         </button>
         <button
           class="bg-chip-bg text-text-primary border border-border rounded-md px-3 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
-          @click="
-            $emit('save')
-            $emit('close')
-          "
+          @click="emitAndClose('save')"
         >
           💾 Save
         </button>
         <button
           class="bg-chip-bg text-text-primary border border-border rounded-md px-3 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
-          @click="
-            $emit('load')
-            $emit('close')
-          "
+          @click="emitAndClose('load')"
         >
           📂 Load
         </button>
         <button
           class="bg-chip-bg text-text-primary border border-border rounded-md px-3 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
-          @click="
-            $emit('help')
-            $emit('close')
-          "
+          @click="emitAndClose('help')"
         >
           ❓ Help
         </button>

--- a/web/src/components/TopBar.vue
+++ b/web/src/components/TopBar.vue
@@ -27,25 +27,25 @@ defineEmits<{
     <div class="flex items-center gap-2">
       <div class="flex gap-2">
         <button
-          class="bg-chip-bg text-text-primary border border-border rounded-md px-3.5 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
+          class="max-md:hidden bg-chip-bg text-text-primary border border-border rounded-md px-3.5 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
           @click="$emit('quickSave')"
         >
           ⚡ Quicksave
         </button>
         <button
-          class="bg-chip-bg text-text-primary border border-border rounded-md px-3.5 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
+          class="max-md:hidden bg-chip-bg text-text-primary border border-border rounded-md px-3.5 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
           @click="$emit('quickLoad')"
         >
           ⚡ Quickload
         </button>
         <button
-          class="bg-chip-bg text-text-primary border border-border rounded-md px-3.5 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
+          class="max-md:hidden bg-chip-bg text-text-primary border border-border rounded-md px-3.5 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
           @click="$emit('save')"
         >
           💾 Save
         </button>
         <button
-          class="bg-chip-bg text-text-primary border border-border rounded-md px-3.5 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
+          class="max-md:hidden bg-chip-bg text-text-primary border border-border rounded-md px-3.5 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
           @click="$emit('load')"
         >
           📂 Load
@@ -67,7 +67,7 @@ defineEmits<{
           {{ soundMuted ? '🔕' : '🔔' }}
         </button>
         <button
-          class="bg-chip-bg text-text-primary border border-border rounded-md px-3.5 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
+          class="max-md:hidden bg-chip-bg text-text-primary border border-border rounded-md px-3.5 py-1.5 cursor-pointer text-sm transition-colors hover:bg-chip-hover"
           @click="$emit('help')"
         >
           ❓ Help


### PR DESCRIPTION
## Summary

Fixes the mobile toolbar overflow where 8 buttons caused the page to be horizontally scrollable on handheld devices.

## Changes

- **TopBar.vue**: hide Quicksave/Quickload/Save/Load/Help on mobile screens (max-md:hidden) - only Title, Music mute, Sound mute, and Hamburger remain visible
- **MobileDrawer.vue**: add action chips row at top of drawer (Quicksave, Quickload, Save, Load, Help) — each chip emits its action and auto-closes the drawer
- **GameLayout.vue**: wire new MobileDrawer action emits to existing handlers (store.saveGame, store.loadGame, onOpenSaveDialog, onOpenLoadDialog, onHelp)
- **game.spec.ts**: 3 new e2e tests covering mobile toolbar overflow fix

## Pre-merge Checklist

- [x] Lint passes
- [x] Prettier passes
- [x] vue-tsc passes
- [x] Unit tests pass (254 tests)
- [x] E2E tests pass (full suite)
- [x] Build passes

Formatting constraints verified